### PR TITLE
Adds REST API namespaces + small refactors

### DIFF
--- a/spec/clj/c3kit/wire/ajax_spec.clj
+++ b/spec/clj/c3kit/wire/ajax_spec.clj
@@ -1,6 +1,7 @@
 (ns c3kit.wire.ajax-spec
   (:require [c3kit.apron.log :as log]
             [c3kit.apron.utilc :as utilc]
+            [c3kit.wire.spec.spec-helperc :as spec-helperc]
             [c3kit.wire.ajax :as sut]
             [c3kit.wire.api :as api]
             [c3kit.wire.flashc :as flashc]
@@ -135,7 +136,7 @@
               response (wrapped {:method :test})]
           (should= 200 (:status response))
           (should= :error (sut/status response))
-          (should= "Our apologies. An error occurred and we have been notified." (-> response :body :flash first :text))
+          (should= spec-helperc/default-error-message (-> response :body :flash first :text))
           (should= :error (-> response :body :flash first :level))))
       (should= "java.lang.Exception: test" (log/captured-logs-str)))
 

--- a/spec/clj/c3kit/wire/ajax_spec.clj
+++ b/spec/clj/c3kit/wire/ajax_spec.clj
@@ -14,6 +14,12 @@
 (describe "Ajax"
 
   (context "wrap-add-api-version"
+    (it "is deprecated"
+      (log/capture-logs
+        (sut/wrap-add-api-version identity)
+        (should= "c3kit.wire.ajax/wrap-add-api-version is deprecated. Use c3kit.wire.api/wrap-add-api-version instead."
+                 (log/captured-logs-str))))
+
     (it "missing body"
       (should= {} (handle-add-api-version {})))
 

--- a/spec/clj/c3kit/wire/api_spec.clj
+++ b/spec/clj/c3kit/wire/api_spec.clj
@@ -1,0 +1,25 @@
+(ns c3kit.wire.api-spec
+  (:require [speclj.core :refer :all]
+            [c3kit.wire.api :as sut]))
+
+(def handle-add-api-version (sut/wrap-add-api-version identity))
+
+(describe "Api"
+
+  (context "wrap-add-api-version"
+    (it "missing body"
+      (should= {} (handle-add-api-version {})))
+
+    (it "string body"
+      (let [request {:body "hello"}]
+        (should= request (handle-add-api-version request))))
+
+    (it "map body"
+      (sut/configure! :version "123")
+      (let [request  {:body {:hello :world}}
+            response (handle-add-api-version request)]
+        (should= (assoc-in request [:body :version] "123") response)))
+
+    (it "vector body"
+      (let [request {:body [:hello :world]}]
+        (should= request (handle-add-api-version request))))))

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -56,11 +56,11 @@
 
   (context "wrappers"
 
-    (context "wrap-catch-api-errors"
+    (context "wrap-catch-rest-errors"
       (it "default handler"
         (api/configure! :rest-on-ex nil)
         (log/capture-logs
-          (let [wrapped (sut/wrap-catch-api-errors (fn [_] (throw (Exception. "test"))))]
+          (let [wrapped (sut/wrap-catch-rest-errors (fn [_] (throw (Exception. "test"))))]
             (should= (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."})
                      (wrapped {:method :test}))
             (should= "java.lang.Exception: test" (log/captured-logs-str)))))
@@ -68,7 +68,7 @@
       (it "custom handler fn"
         (api/configure! :rest-on-ex (stub :custom-ex-handler {:return :custom-handler-response}))
         (let [e (Exception. "test")
-              wrapped (sut/wrap-catch-api-errors (fn [_] (throw e)))]
+              wrapped (sut/wrap-catch-rest-errors (fn [_] (throw e)))]
           (should= :custom-handler-response (wrapped {:method :test}))
           (should-have-invoked :custom-ex-handler {:with [{:method :test} e]}))))
 

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -1,0 +1,187 @@
+(ns c3kit.wire.rest-spec
+  (:require [c3kit.apron.corec :as ccc]
+            [c3kit.apron.log :as log]
+            [c3kit.apron.utilc :as utilc]
+            [c3kit.wire.api :as api]
+            [speclj.core :refer :all]
+            [org.httpkit.client :as client]
+            [c3kit.wire.restc :as restc]
+            [c3kit.wire.rest :as sut]))
+
+(defmacro test-http-method [f stub callback]
+  `(list
+     (it "sends to url with opts"
+       (~f "https://wire.com" {} ~callback)
+       (should-have-invoked ~stub {:times 1})
+       (should-have-invoked ~stub {:with ["https://wire.com" {} ~callback]})
+       (~f "https://google.com" {:query-params {:a 5}} ~callback)
+       (should-have-invoked ~stub {:times 2})
+       (should-have-invoked ~stub {:with ["https://google.com" {:query-params {:a 5}} ~callback]}))
+
+     (it "converts body to json and adds content-type"
+       (let [body# {:some-data [{:yes :no} 45]}]
+         (~f "https://example.com" {:body body#} ~callback)
+         (should-have-invoked ~stub {:with ["https://example.com"
+                                            {:body (utilc/->json body#)
+                                             :headers {"Content-Type" "application/json"}}
+                                            ~callback]})))
+
+     (it "doesn't override content-type of opts"
+       (let [body# {:more-data 25}]
+         (~f "http://test.net" {:body body# :headers {"Content-Type" "custom-type"}} ~callback)
+         (should-have-invoked ~stub {:with ["http://test.net"
+                                            {:body (utilc/->json body#)
+                                             :headers {"Content-Type" "custom-type"}}
+                                            ~callback]})))))
+
+(defmacro test-http-method-sync [f stub]
+  `(list
+     (test-http-method ~f ~stub ccc/noop)
+
+     (it "returns response"
+       (should= :http-response-data (~f "https://wire.com" {} ccc/noop)))))
+
+(defmacro test-http-method-async [f stub]
+  `(list
+     (test-http-method ~f ~stub ccc/noop)
+
+     (it "returns promise"
+       (should= :http-response-data @(~f "https://wire.com" {} ccc/noop)))))
+
+(defn request-handler [request response]
+  (merge response {:request request}))
+
+(def handle-json-request (sut/wrap-api-json-request #(request-handler % nil)))
+(def handle-json-kw-request (sut/wrap-api-json-request #(request-handler % nil) {:key-words? true}))
+(defn handle-json-response [body]
+  (sut/wrap-api-json-response #(request-handler % body)))
+
+
+(context "Rest"
+  (with-stubs)
+
+  (redefs-around [client/get (stub :client/get {:return (delay :http-response-data)})
+                  client/post (stub :client/post {:return (delay :http-response-data)})
+                  client/put (stub :client/put {:return (delay :http-response-data)})])
+
+  (context "get"
+    (context "synchronously"
+      (test-http-method-sync sut/get! :client/get))
+
+    (context "asynchronously"
+      (test-http-method-async sut/get-async! :client/get)))
+
+  (context "post"
+    (context "synchronously"
+      (test-http-method-sync sut/post! :client/post))
+
+    (context "asynchronously"
+      (test-http-method-async sut/post-async! :client/post)))
+
+  (context "put"
+    (context "synchronously"
+      (test-http-method-sync sut/put! :client/put))
+
+    (context "asynchronously"
+      (test-http-method-async sut/put-async! :client/put)))
+
+  (context "wrappers"
+
+    (context "wrap-catch-api-errors"
+      (it "default handler"
+        (api/configure! :rest-on-ex nil)
+        (log/capture-logs
+          (let [wrapped (sut/wrap-catch-api-errors (fn [_] (throw (Exception. "test"))))]
+            (should= (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."})
+                     (wrapped {:method :test}))
+            (should= "java.lang.Exception: test" (log/captured-logs-str)))))
+
+      (it "custom handler fn"
+        (api/configure! :rest-on-ex (stub :custom-ex-handler {:return :custom-handler-response}))
+        (let [e (Exception. "test")
+              wrapped (sut/wrap-catch-api-errors (fn [_] (throw e)))]
+          (should= :custom-handler-response (wrapped {:method :test}))
+          (should-have-invoked :custom-ex-handler {:with [{:method :test} e]}))))
+
+    (context "wrap-api-json-request"
+      (it "empty request change nothing"
+        (let [response (handle-json-request {})]
+          (should= {} (:request response))))
+
+      (it "request with body converts from json"
+        (let [body (utilc/->json {:my-data 123})
+              response (handle-json-request {:body body})]
+          (should= {:body (utilc/<-json body)} (:request response))))
+
+      (context "with keywords"
+        (it "empty request changes nothing"
+          (let [response (handle-json-kw-request {})]
+            (should= {} (:request response))))
+
+        (it "request with body converts from json with keywords"
+          (let [body (utilc/->json {:my-data 123})
+                response (handle-json-kw-request {:body body})]
+            (should= {:body (utilc/<-json-kw body)} (:request response))))))
+
+    (context "wrap-api-json-response"
+      (it "empty request changes nothing"
+        (let [response-handler (handle-json-response {})]
+          (should-be-nil (:body (response-handler {})))))
+
+      (it "headers but no body changes nothing"
+        (let [response-handler (handle-json-response {:headers {"Hi" "bye"}})
+              response (response-handler {})]
+          (should-be-nil (:body response))
+          (should= {"Hi" "bye"} (:headers response))))
+
+      (context "request with body"
+        (it "converts body to json"
+          (let [body {:my-data 123}
+                response-handler (handle-json-response {:body body})]
+            (should= (utilc/->json body) (:body (response-handler {})))))
+
+        (it "sets Content-Type to application/json"
+          (let [body {:my-data 123}
+                response-handler (handle-json-response {:body body})]
+            (should= {"Content-Type" "application/json"} (:headers (response-handler {})))))
+
+        (it "doesn't override Content-Type"
+          (let [body {:my-data 123}
+                response-handler (handle-json-response {:body body
+                                                          :headers {"Content-Type" "custom-type"}})]
+            (should= {"Content-Type" "custom-type"} (:headers (response-handler {})))))))
+
+    (context "wrap-rest"
+      (before (api/configure! :rest-on-ex (stub :custom-ex-handler {:return :custom-handler-response}))
+              (api/configure! :version "123"))
+
+      (it "catches api-errors"
+        (let [e (Exception. "test")
+              wrapped (sut/wrap-rest (fn [_] (throw e)))]
+          (should= :custom-handler-response (wrapped {:method :test}))
+          (should-have-invoked :custom-ex-handler {:with [{:method :test} e]})))
+
+      (it "converts response to json"
+        (let [body {:my-data 123}
+              handle-json-response (fn [body] (sut/wrap-rest #(request-handler % body)))
+              response-handler (handle-json-response {:body body})]
+          (should= (utilc/->json (assoc body :version "123")) (:body (response-handler {})))))
+
+      (it "adds api version"
+        (let [response {:body {:hello :world}}
+              handle-add-api-version (sut/wrap-rest #(request-handler % response))
+              versioned-response (handle-add-api-version nil)]
+          (should= (utilc/->json {:hello :world :version "123"})
+                   (:body versioned-response))))
+
+      (it "converts request from json"
+        (let [body (utilc/->json {:my-data 123})
+              handle-json-request (sut/wrap-rest #(request-handler % nil))
+              response (handle-json-request {:body body})]
+          (should= {:body (utilc/<-json body)} (:request response))))
+
+      (it "converts request from json with keywords"
+        (let [body (utilc/->json {:my-data 123})
+              handle-json-request (sut/wrap-rest #(request-handler % nil) {:key-words? true})
+              response (handle-json-request {:body body})]
+          (should= {:body (utilc/<-json-kw body)} (:request response)))))))

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -60,7 +60,7 @@
   (merge response {:request request}))
 
 (def handle-json-request (sut/wrap-api-json-request #(request-handler % nil)))
-(def handle-json-kw-request (sut/wrap-api-json-request #(request-handler % nil) {:key-words? true}))
+(def handle-json-kw-request (sut/wrap-api-json-request #(request-handler % nil) {:keywords? true}))
 (defn handle-json-response [body]
   (sut/wrap-api-json-response #(request-handler % body)))
 
@@ -190,6 +190,6 @@
 
       (it "converts request from json with keywords"
         (let [body (utilc/->json {:my-data 123})
-              handle-json-request (sut/wrap-rest #(request-handler % nil) {:key-words? true})
+              handle-json-request (sut/wrap-rest #(request-handler % nil) {:keywords? true})
               response (handle-json-request {:body (io/input-stream (.getBytes body))})]
           (should= {:body (utilc/<-json-kw body)} (:request response)))))))

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -14,37 +14,45 @@
 
 (def handle-json-request (sut/wrap-api-json-request #(request-handler % nil)))
 (def handle-json-kw-request (sut/wrap-api-json-request #(request-handler % nil) {:keywords? true}))
-(defn handle-json-response [body]
-  (sut/wrap-api-json-response #(request-handler % body)))
+(defn handle-json-response [response]
+  (sut/wrap-api-json-response #(request-handler % response)))
 
+(def http-stub-response :http-response-data)
+
+(defn httpkit-response [_url _opts callback]
+  (delay
+    (if callback
+      (do (callback http-stub-response)
+          nil)
+      http-stub-response)))
 
 (context "Rest"
   (with-stubs)
 
-  (redefs-around [client/get (stub :client/get {:return (delay :http-response-data)})
-                  client/post (stub :client/post {:return (delay :http-response-data)})
-                  client/put (stub :client/put {:return (delay :http-response-data)})])
+  (redefs-around [client/get (stub :client/get {:invoke httpkit-response})
+                  client/post (stub :client/post {:invoke httpkit-response})
+                  client/put (stub :client/put {:invoke httpkit-response})])
 
   (context "get"
     (context "synchronously"
-      (test-http-method-sync sut/get! :client/get :http-response-data))
+      (test-http-method-sync sut/get! :client/get http-stub-response))
 
     (context "asynchronously"
-      (test-http-method-async sut/get-async! :client/get :http-response-data)))
+      (test-http-method-async sut/get-async! :client/get http-stub-response)))
 
   (context "post"
     (context "synchronously"
-      (test-http-method-sync sut/post! :client/post :http-response-data))
+      (test-http-method-sync sut/post! :client/post http-stub-response))
 
     (context "asynchronously"
-      (test-http-method-async sut/post-async! :client/post :http-response-data)))
+      (test-http-method-async sut/post-async! :client/post http-stub-response)))
 
   (context "put"
     (context "synchronously"
-      (test-http-method-sync sut/put! :client/put :http-response-data))
+      (test-http-method-sync sut/put! :client/put http-stub-response))
 
     (context "asynchronously"
-      (test-http-method-async sut/put-async! :client/put :http-response-data)))
+      (test-http-method-async sut/put-async! :client/put http-stub-response)))
 
   (context "wrappers"
 

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -3,6 +3,7 @@
             [c3kit.apron.log :as log]
             [c3kit.apron.utilc :as utilc]
             [c3kit.wire.api :as api]
+            [clojure.java.io :as io]
             [speclj.core :refer :all]
             [org.httpkit.client :as client]
             [c3kit.wire.restc :as restc]
@@ -117,7 +118,7 @@
 
       (it "request with body converts from json"
         (let [body (utilc/->json {:my-data 123})
-              response (handle-json-request {:body body})]
+              response (handle-json-request {:body (io/input-stream (.getBytes body))})]
           (should= {:body (utilc/<-json body)} (:request response))))
 
       (context "with keywords"
@@ -127,7 +128,7 @@
 
         (it "request with body converts from json with keywords"
           (let [body (utilc/->json {:my-data 123})
-                response (handle-json-kw-request {:body body})]
+                response (handle-json-kw-request {:body (io/input-stream (.getBytes body))})]
             (should= {:body (utilc/<-json-kw body)} (:request response))))))
 
     (context "wrap-api-json-response"
@@ -184,11 +185,11 @@
       (it "converts request from json"
         (let [body (utilc/->json {:my-data 123})
               handle-json-request (sut/wrap-rest #(request-handler % nil))
-              response (handle-json-request {:body body})]
+              response (handle-json-request {:body (io/input-stream (.getBytes body))})]
           (should= {:body (utilc/<-json body)} (:request response))))
 
       (it "converts request from json with keywords"
         (let [body (utilc/->json {:my-data 123})
               handle-json-request (sut/wrap-rest #(request-handler % nil) {:key-words? true})
-              response (handle-json-request {:body body})]
+              response (handle-json-request {:body (io/input-stream (.getBytes body))})]
           (should= {:body (utilc/<-json-kw body)} (:request response)))))))

--- a/spec/clj/c3kit/wire/rest_spec.clj
+++ b/spec/clj/c3kit/wire/rest_spec.clj
@@ -2,6 +2,7 @@
   (:require [c3kit.apron.log :as log]
             [c3kit.apron.utilc :as utilc]
             [c3kit.wire.api :as api]
+            [c3kit.wire.spec.spec-helperc :as spec-helperc]
             [clojure.java.io :as io]
             [speclj.core :refer :all]
             [org.httpkit.client :as client]
@@ -61,7 +62,7 @@
         (api/configure! :rest-on-ex nil)
         (log/capture-logs
           (let [wrapped (sut/wrap-catch-rest-errors (fn [_] (throw (Exception. "test"))))]
-            (should= (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."})
+            (should= (restc/internal-error {:message spec-helperc/default-error-message})
                      (wrapped {:method :test}))
             (should= "java.lang.Exception: test" (log/captured-logs-str)))))
 

--- a/spec/cljc/c3kit/wire/restc_spec.cljc
+++ b/spec/cljc/c3kit/wire/restc_spec.cljc
@@ -80,6 +80,9 @@
   (context "Internal Server Error"
     (test-rest sut/internal-error 500))
 
+  (it "handles not-found error"
+    (should= (sut/not-found "abc.com") (sut/not-found-handler {:uri "abc.com"})))
+
   (it "gets status of response"
     (should= 200 (sut/status (sut/response 200)))
     (should= 404 (sut/status (sut/response 404))))

--- a/spec/cljc/c3kit/wire/restc_spec.cljc
+++ b/spec/cljc/c3kit/wire/restc_spec.cljc
@@ -1,0 +1,114 @@
+(ns c3kit.wire.restc-spec
+  (:require [c3kit.apron.utilc :as utilc]
+            [speclj.core #?(:clj :refer :cljs :refer-macros) [should-not should context describe should-be-nil should-be it should= should-contain should-not-be]]
+            [c3kit.wire.spec.spec-helperc #?(:clj :refer :cljs :refer-macros) [test-rest test-rest-no-params]]
+            [c3kit.wire.restc :as sut]))
+
+(describe "Rest"
+
+  (context "response"
+    (it "sets status and no headers"
+      (should= {:status 123 :headers {}} (sut/response 123))
+      (should= {:status 321 :headers {}} (sut/response 321)))
+
+    (it "sets status, body, and no headers"
+      (should= {:status 123 :headers {} :body {:my :body}}
+               (sut/response 123 {:my :body}))
+      (should= {:status 321 :headers {} :body {:more :data}}
+               (sut/response 321 {:more :data})))
+
+    (it "sets status, body, and headers"
+      (should= {:status 123 :headers {"Authorization" "abc"} :body {:my :body}}
+               (sut/response 123 {:my :body} {"Authorization" "abc"}))
+      (should= {:status 321 :headers {"my-header" "hello"} :body {:more :data}}
+               (sut/response 321 {:more :data} {"my-header" "hello"}))))
+
+  (context "OK"
+    (test-rest sut/ok 200))
+
+  (context "Created"
+    (test-rest sut/created 201))
+
+  (context "Accepted"
+    (test-rest sut/accepted 202))
+
+  (context "Non-Authoritative Information"
+    (test-rest sut/non-authoritative 203))
+
+  (context "No Content"
+    (test-rest-no-params sut/no-content 204)
+
+    (context "with headers"
+
+      (let [response (sut/no-content {:my-header 123})]
+        (list
+          (it "returns status code 204"
+            (should= 204 (:status response)))
+
+          (it "returns headers"
+            (let [response (sut/no-content {:my-header 123})]
+              (should= {:my-header 123} (:headers response))))))))
+
+  (context "Bad Request"
+    (test-rest sut/bad-request 400))
+
+  (context "Unauthorized"
+    (test-rest sut/unauthorized 401)
+
+    (context "with WWW-Authenticate"
+      (let [response (sut/unauthorized {:data "hi"} {:authorization "def"} "Basic")]
+        (list
+          (it "returns status code 401"
+            (should= 401 (:status response)))
+
+          (it "returns body"
+            (should= {:data "hi"} (:body response)))
+
+          (it "includes WWW-Authenticate in headers"
+            (should= {:authorization "def"
+                      "WWW-Authenticate" "Basic"} (:headers response)))))))
+
+  (context "Payment Required"
+    (test-rest sut/payment-required 402))
+
+  (context "Forbidden"
+    (test-rest sut/forbidden 403))
+
+  (context "Not Found"
+    (test-rest sut/not-found 404))
+
+  (context "Internal Server Error"
+    (test-rest sut/internal-error 500))
+
+  (it "gets status of response"
+    (should= 200 (sut/status (sut/response 200)))
+    (should= 404 (sut/status (sut/response 404))))
+
+  (it "checks status of response"
+    (should (sut/success? (sut/response 200)))
+    (should-not (sut/success? (sut/response 300)))
+    (should (sut/success? (sut/response 201)))
+    (should-not (sut/success? (sut/response 199)))
+
+    (should (sut/error? (sut/response 400)))
+    (should-not (sut/error? (sut/response 399)))
+    (should (sut/error? (sut/response 401))))
+
+  (it "gets body of response"
+    (should= "I am a body" (sut/body (sut/response 200 "I am a body")))
+    (should= {:map :body} (sut/body (sut/response 200 {:map :body}))))
+
+  (it "gets un-json'd body"
+    (should= "I am a body" (sut/<-json-body (sut/response 200 (utilc/->json "I am a body"))))
+    (should= {"map" "body"} (sut/<-json-body (sut/response 200 (utilc/->json {:map :body})))))
+
+  (it "gets un-json'd body with keywords"
+    (should= {:map "body"} (sut/<-json-kw-body (sut/response 200 (utilc/->json {:map :body}))))
+    (should= {:more "data"} (sut/<-json-kw-body (sut/response 200 (utilc/->json {:more :data})))))
+
+  (it "gets headers of response"
+    (should= {} (sut/headers (sut/response 200 nil)))
+    (should= {"Authorization" "123"}
+             (sut/headers (sut/response 200 nil {"Authorization" "123"}))))
+
+  )

--- a/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
+++ b/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
@@ -1,0 +1,47 @@
+(ns c3kit.wire.spec.spec-helperc
+  (:require [speclj.core #?(:clj :refer :cljs :refer-macros) [context should-be-nil it should=]]))
+
+#?(:clj (defmacro test-rest-no-params [f status-code]
+          `(context "no params"
+
+            (let [response# (~f)]
+              (list
+                (it (str "returns status code " ~status-code)
+                  (should= ~status-code (:status response#)))
+
+                (it "returns no body"
+                  (should-be-nil (:body response#)))
+
+                (it "returns no headers"
+                  (should= {} (:headers response#))))))))
+
+#?(:clj (defmacro test-rest [f status-code]
+          `(list
+
+             (test-rest-no-params ~f ~status-code)
+
+             (context "with body"
+
+               (let [response# (~f {:hello :goodbye})]
+                 (list
+                   (it (str "returns status code " ~status-code)
+                     (should= ~status-code (:status response#)))
+
+                   (it "returns body"
+                     (should= {:hello :goodbye}  (:body response#)))
+
+                   (it "returns no headers"
+                     (should= {} (:headers response#))))))
+
+             (context "with body and headers"
+
+               (let [response# (~f {:my-key 5} {:authorization "abc"})]
+                 (list
+                   (it (str "returns status code " ~status-code)
+                     (should= ~status-code (:status response#)))
+
+                   (it "returns body"
+                     (should= {:my-key 5} (:body response#)))
+
+                   (it "returns headers"
+                     (should= {:authorization "abc"} (:headers response#)))))))))

--- a/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
+++ b/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
@@ -1,5 +1,7 @@
 (ns c3kit.wire.spec.spec-helperc
-  (:require [speclj.core #?(:clj :refer :cljs :refer-macros) [context should-be-nil it should=]]))
+  (:require [c3kit.apron.corec :as ccc]
+            [c3kit.apron.utilc :as utilc]
+            [speclj.core #?(:clj :refer :cljs :refer-macros) [should-have-invoked context should-be-nil it should=]]))
 
 #?(:clj (defmacro test-rest-no-params [f status-code]
           `(context "no params"
@@ -45,3 +47,53 @@
 
                    (it "returns headers"
                      (should= {:authorization "abc"} (:headers response#)))))))))
+
+(defn maybe-conj [coll x]
+  (if x
+    (conj coll x)
+    coll))
+
+#?(:clj
+  (defmacro test-http-method [f stub & [callback]]
+    `(list
+       (it "sends to url with opts"
+         (apply ~f (maybe-conj ["https://wire.com" {}] ~callback))
+         (should-have-invoked ~stub {:times 1})
+         (should-have-invoked ~stub {:with ["https://wire.com" {} ~callback]})
+         (apply ~f (maybe-conj ["https://google.com" {:query-params {:a 5}}] ~callback))
+         (should-have-invoked ~stub {:times 2})
+         (should-have-invoked ~stub {:with ["https://google.com" {:query-params {:a 5}} ~callback]}))
+
+       (it "converts body to json and adds content-type"
+         (let [body# {:some-data [{:yes :no} 45]}]
+           (apply ~f (maybe-conj ["https://example.com" {:body body#}] ~callback))
+           (should-have-invoked ~stub {:with ["https://example.com"
+                                              {:body (utilc/->json body#)
+                                               :headers {"Content-Type" "application/json"}}
+                                              ~callback]})))
+
+       (it "doesn't override content-type of opts"
+         (let [body# {:more-data 25}]
+           (apply ~f (maybe-conj ["http://test.net"
+                                  {:body body# :headers {"Content-Type" "custom-type"}}]
+                                 ~callback))
+           (should-have-invoked ~stub {:with ["http://test.net"
+                                              {:body (utilc/->json body#)
+                                               :headers {"Content-Type" "custom-type"}}
+                                              ~callback]}))))))
+
+#?(:clj
+  (defmacro test-http-method-sync [f stub stub-response]
+    `(list
+       (test-http-method ~f ~stub)
+
+       (it "returns response"
+         (should= ~stub-response (~f "https://wire.com" {}))))))
+
+#?(:clj
+  (defmacro test-http-method-async [f stub stub-response]
+    `(list
+       (test-http-method ~f ~stub ccc/noop)
+
+       (it "returns promise"
+         (should= ~stub-response @(~f "https://wire.com" {} ccc/noop))))))

--- a/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
+++ b/spec/cljc/c3kit/wire/spec/spec_helperc.cljc
@@ -3,6 +3,8 @@
             [c3kit.apron.utilc :as utilc]
             [speclj.core #?(:clj :refer :cljs :refer-macros) [stub should-have-invoked context should-be-nil it should=]]))
 
+(def default-error-message "Our apologies. An error occurred and we have been notified.")
+
 #?(:clj (defmacro test-rest-no-params [f status-code]
           `(context "no params"
 

--- a/spec/cljs/c3kit/wire/rest_spec.cljs
+++ b/spec/cljs/c3kit/wire/rest_spec.cljs
@@ -1,6 +1,5 @@
 (ns c3kit.wire.rest-spec
-  (:require [c3kit.apron.corec :as ccc]
-            [speclj.core :refer-macros [tags focus-describe should-not-be-nil should-have-invoked stub redefs-around with-stubs should-not should context describe should-be-nil should-be it should= should-contain should-not-be]]
+  (:require [speclj.core :refer-macros [tags focus-describe should-not-be-nil should-have-invoked stub redefs-around with-stubs should-not should context describe should-be-nil should-be it should= should-contain should-not-be]]
             [c3kit.wire.spec.spec-helperc :refer-macros [test-cljs-http-method]]
             [cljs.core.async :refer-macros [go]]
             [cljs.core.async :as async]
@@ -17,11 +16,11 @@
                   client/post (stub :client/post {:invoke cljs-http-response})
                   client/put (stub :client/put {:invoke cljs-http-response})])
 
-  (context "get"
+  (context "get!"
     (test-cljs-http-method sut/get! :client/get))
 
-  (context "post"
+  (context "post!"
     (test-cljs-http-method sut/post! :client/post))
 
-  (context "put"
+  (context "put!"
     (test-cljs-http-method sut/put! :client/put)))

--- a/spec/cljs/c3kit/wire/rest_spec.cljs
+++ b/spec/cljs/c3kit/wire/rest_spec.cljs
@@ -1,0 +1,27 @@
+(ns c3kit.wire.rest-spec
+  (:require [c3kit.apron.corec :as ccc]
+            [speclj.core :refer-macros [tags focus-describe should-not-be-nil should-have-invoked stub redefs-around with-stubs should-not should context describe should-be-nil should-be it should= should-contain should-not-be]]
+            [c3kit.wire.spec.spec-helperc :refer-macros [test-cljs-http-method]]
+            [cljs.core.async :refer-macros [go]]
+            [cljs.core.async :as async]
+            [cljs-http.client :as client]
+            [c3kit.wire.rest :as sut]))
+
+(defn cljs-http-response [& _]
+  (async/chan))
+
+(describe "Rest"
+  (with-stubs)
+
+  (redefs-around [client/get (stub :client/get {:invoke cljs-http-response})
+                  client/post (stub :client/post {:invoke cljs-http-response})
+                  client/put (stub :client/put {:invoke cljs-http-response})])
+
+  (context "get"
+    (test-cljs-http-method sut/get! :client/get))
+
+  (context "post"
+    (test-cljs-http-method sut/post! :client/post))
+
+  (context "put"
+    (test-cljs-http-method sut/put! :client/put)))

--- a/src/clj/c3kit/wire/ajax.clj
+++ b/src/clj/c3kit/wire/ajax.clj
@@ -100,6 +100,6 @@
 (defn wrap-ajax [handler]
   (-> handler
       wrap-catch-api-errors
-      wrap-add-api-version
+      api/wrap-add-api-version
       wrap-api-transit-response
       wrap-transit-params))

--- a/src/clj/c3kit/wire/ajax.clj
+++ b/src/clj/c3kit/wire/ajax.clj
@@ -90,6 +90,7 @@
         response))))
 
 (defn wrap-add-api-version [handler]
+  (log/warn "c3kit.wire.ajax/wrap-add-api-version is deprecated. Use c3kit.wire.api/wrap-add-api-version instead.")
   (fn [request]
     (let [{:keys [body] :as response} (handler request)]
       (if (map? body)

--- a/src/clj/c3kit/wire/ajax.clj
+++ b/src/clj/c3kit/wire/ajax.clj
@@ -51,7 +51,7 @@
 (defn default-ajax-ex-handler [request ex]
   (log/error ex)
   ;(errors/send-error-email request e)
-  (error nil "Our apologies. An error occurred and we have been notified."))
+  (error nil api/default-error-message))
 
 (defn wrap-catch-api-errors [handler]
   (fn [request]

--- a/src/clj/c3kit/wire/api.clj
+++ b/src/clj/c3kit/wire/api.clj
@@ -5,6 +5,8 @@
             [clojure.java.io :as io]
             [clojure.string :as str]))
 
+(def default-error-message "Our apologies. An error occurred and we have been notified.")
+
 (def default-config {
                      :ajax-on-ex  'c3kit.wire.ajax/default-ajax-ex-handler ;; (fn [request e])
                      :version     "undefined"

--- a/src/clj/c3kit/wire/api.clj
+++ b/src/clj/c3kit/wire/api.clj
@@ -37,3 +37,10 @@
 
 (defn maybe-entity-errors [entity]
   (some->> entity schema/message-seq (str/join " , ") (apic/fail nil)))
+
+(defn wrap-add-api-version [handler]
+  (fn [request]
+    (let [{:keys [body] :as response} (handler request)]
+      (if (map? body)
+        (assoc-in response [:body :version] (version))
+        response))))

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -21,23 +21,23 @@
       (maybe-update-body utilc/->json)
       maybe-update-content-type))
 
-(defn get-async! [url opts callback]
+(defn get-async! [url opts & [callback]]
   (client/get url (maybe-update-opts opts) callback))
 
-(defn get! [url opts callback]
-  @(get-async! url opts callback))
+(defn get! [url opts]
+  @(get-async! url opts))
 
-(defn post-async! [url opts callback]
+(defn post-async! [url opts & [callback]]
   (client/post url (maybe-update-opts opts) callback))
 
-(defn post! [url opts callback]
-  @(post-async! url opts callback))
+(defn post! [url opts]
+  @(post-async! url opts))
 
-(defn put-async! [url opts callback]
+(defn put-async! [url opts & [callback]]
   (client/put url (maybe-update-opts opts) callback))
 
-(defn put! [url opts callback]
-  @(put-async! url opts callback))
+(defn put! [url opts]
+  @(put-async! url opts))
 
 (defn default-rest-ex-handler [_request ex]
   (log/error ex)

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -59,7 +59,7 @@
 
 (defn wrap-api-json-request [handler & [opts]]
   (fn [request]
-    (handler (maybe-update-body request (if (:key-words? opts)
+    (handler (maybe-update-body request (if (:keywords? opts)
                                           <-json-kw-slurp
                                           <-json-slurp)))))
 

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -43,7 +43,7 @@
   (log/error ex)
   (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."}))
 
-(defn wrap-catch-api-errors [handler]
+(defn wrap-catch-rest-errors [handler]
   (fn [request]
     (try
       (handler request)
@@ -71,7 +71,7 @@
 
 (defn wrap-rest [handler & [opts]]
   (-> handler
-      wrap-catch-api-errors
+      wrap-catch-rest-errors
       api/wrap-add-api-version
       wrap-api-json-response
       (wrap-api-json-request opts)))

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -4,37 +4,22 @@
             [c3kit.apron.utilc :as utilc]
             [c3kit.wire.api :as api]
             [c3kit.wire.restc :as restc]
-            [org.httpkit.client :as client]
-            [ring.util.response :as response]))
-
-(defn- maybe-update-body [{:keys [body] :as request} f]
-  (cond-> request
-          body (update :body f)))
-
-(defn- maybe-update-content-type [{:keys [headers body] :as request}]
-  (cond-> request
-          (and body (not (get headers "Content-Type")))
-          (response/content-type "application/json")))
-
-(defn- maybe-update-opts [opts]
-  (-> opts
-      (maybe-update-body utilc/->json)
-      maybe-update-content-type))
+            [org.httpkit.client :as client]))
 
 (defn get-async! [url opts & [callback]]
-  (client/get url (maybe-update-opts opts) callback))
+  (client/get url (restc/-maybe-update-req opts) callback))
 
 (defn get! [url opts]
   @(get-async! url opts))
 
 (defn post-async! [url opts & [callback]]
-  (client/post url (maybe-update-opts opts) callback))
+  (client/post url (restc/-maybe-update-req opts) callback))
 
 (defn post! [url opts]
   @(post-async! url opts))
 
 (defn put-async! [url opts & [callback]]
-  (client/put url (maybe-update-opts opts) callback))
+  (client/put url (restc/-maybe-update-req opts) callback))
 
 (defn put! [url opts]
   @(put-async! url opts))
@@ -59,15 +44,14 @@
 
 (defn wrap-api-json-request [handler & [opts]]
   (fn [request]
-    (handler (maybe-update-body request (if (:keywords? opts)
+    (handler (restc/-maybe-update-body request (if (:keywords? opts)
                                           <-json-kw-slurp
                                           <-json-slurp)))))
 
 (defn wrap-api-json-response [handler]
   (fn [request]
     (-> (handler request)
-        (maybe-update-body utilc/->json)
-        maybe-update-content-type)))
+        restc/-maybe-update-req)))
 
 (defn wrap-rest [handler & [opts]]
   (-> handler

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -1,0 +1,72 @@
+(ns c3kit.wire.rest
+  (:require [c3kit.apron.log :as log]
+            [c3kit.apron.util :as util]
+            [c3kit.apron.utilc :as utilc]
+            [c3kit.wire.api :as api]
+            [c3kit.wire.restc :as restc]
+            [org.httpkit.client :as client]
+            [ring.util.response :as response]))
+
+(defn- maybe-update-body [{:keys [body] :as request} f]
+  (cond-> request
+          body (update :body f)))
+
+(defn- maybe-update-content-type [{:keys [headers body] :as request}]
+  (cond-> request
+          (and body (not (get headers "Content-Type")))
+          (response/content-type "application/json")))
+
+(defn- maybe-update-opts [opts]
+  (-> opts
+      (maybe-update-body utilc/->json)
+      maybe-update-content-type))
+
+(defn get-async! [url opts callback]
+  (client/get url (maybe-update-opts opts) callback))
+
+(defn get! [url opts callback]
+  @(get-async! url opts callback))
+
+(defn post-async! [url opts callback]
+  (client/post url (maybe-update-opts opts) callback))
+
+(defn post! [url opts callback]
+  @(post-async! url opts callback))
+
+(defn put-async! [url opts callback]
+  (client/put url (maybe-update-opts opts) callback))
+
+(defn put! [url opts callback]
+  @(put-async! url opts callback))
+
+(defn default-rest-ex-handler [_request ex]
+  (log/error ex)
+  (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."}))
+
+(defn wrap-catch-api-errors [handler]
+  (fn [request]
+    (try
+      (handler request)
+      (catch Exception e
+        (if-let [ex-handler (util/config-value (:rest-on-ex @api/config))]
+          (ex-handler request e)
+          (default-rest-ex-handler request e))))))
+
+(defn wrap-api-json-request [handler & [opts]]
+  (fn [request]
+    (handler (maybe-update-body request (if (:key-words? opts)
+                                          utilc/<-json-kw
+                                          utilc/<-json)))))
+
+(defn wrap-api-json-response [handler]
+  (fn [request]
+    (-> (handler request)
+        (maybe-update-body utilc/->json)
+        maybe-update-content-type)))
+
+(defn wrap-rest [handler & [opts]]
+  (-> handler
+      wrap-catch-api-errors
+      api/wrap-add-api-version
+      wrap-api-json-response
+      (wrap-api-json-request opts)))

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -41,7 +41,7 @@
 
 (defn default-rest-ex-handler [_request ex]
   (log/error ex)
-  (restc/internal-error {:message "Our apologies. An error occurred and we have been notified."}))
+  (restc/internal-error {:message api/default-error-message}))
 
 (defn wrap-catch-rest-errors [handler]
   (fn [request]

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -52,11 +52,16 @@
           (ex-handler request e)
           (default-rest-ex-handler request e))))))
 
+(defn- <-json-slurp [v]
+  (utilc/<-json (slurp v)))
+(defn- <-json-kw-slurp [v]
+  (utilc/<-json-kw (slurp v)))
+
 (defn wrap-api-json-request [handler & [opts]]
   (fn [request]
     (handler (maybe-update-body request (if (:key-words? opts)
-                                          utilc/<-json-kw
-                                          utilc/<-json)))))
+                                          <-json-kw-slurp
+                                          <-json-slurp)))))
 
 (defn wrap-api-json-response [handler]
   (fn [request]

--- a/src/clj/c3kit/wire/rest.clj
+++ b/src/clj/c3kit/wire/rest.clj
@@ -6,19 +6,28 @@
             [c3kit.wire.restc :as restc]
             [org.httpkit.client :as client]))
 
-(defn get-async! [url opts & [callback]]
+(defn get-async!
+  "If callback is not specified, returns a deref-able promise.
+   If callback is specified, returns nil."
+  [url opts & [callback]]
   (client/get url (restc/-maybe-update-req opts) callback))
 
 (defn get! [url opts]
   @(get-async! url opts))
 
-(defn post-async! [url opts & [callback]]
+(defn post-async!
+  "If callback is not specified, returns a deref-able promise.
+   If callback is specified, returns nil."
+  [url opts & [callback]]
   (client/post url (restc/-maybe-update-req opts) callback))
 
 (defn post! [url opts]
   @(post-async! url opts))
 
-(defn put-async! [url opts & [callback]]
+(defn put-async!
+  "If callback is not specified, returns a deref-able promise.
+   If callback is specified, returns nil."
+  [url opts & [callback]]
   (client/put url (restc/-maybe-update-req opts) callback))
 
 (defn put! [url opts]
@@ -45,8 +54,8 @@
 (defn wrap-api-json-request [handler & [opts]]
   (fn [request]
     (handler (restc/-maybe-update-body request (if (:keywords? opts)
-                                          <-json-kw-slurp
-                                          <-json-slurp)))))
+                                                 <-json-kw-slurp
+                                                 <-json-slurp)))))
 
 (defn wrap-api-json-response [handler]
   (fn [request]

--- a/src/cljc/c3kit/wire/restc.cljc
+++ b/src/cljc/c3kit/wire/restc.cljc
@@ -81,3 +81,17 @@
 (defn <-json-kw-body [response] (utilc/<-json-kw (:body response)))
 
 (defn headers [response] (:headers response))
+
+(defn -maybe-update-body [{:keys [body] :as request} f]
+  (cond-> request
+          body (update :body f)))
+
+(defn -maybe-update-content-type [{:keys [headers body] :as request}]
+  (cond-> request
+          (and body (not (get headers "Content-Type")))
+          (assoc-in [:headers "Content-Type"] "application/json")))
+
+(defn -maybe-update-req [req]
+  (-> req
+      (-maybe-update-body utilc/->json)
+      -maybe-update-content-type))

--- a/src/cljc/c3kit/wire/restc.cljc
+++ b/src/cljc/c3kit/wire/restc.cljc
@@ -1,0 +1,80 @@
+(ns c3kit.wire.restc
+  (:require [c3kit.apron.utilc :as utilc]))
+
+(defn response
+  ([status]
+   {:status status
+    :headers {}})
+  ([status body]
+   (assoc (response status) :body body))
+  ([status body headers]
+   (assoc (response status body) :headers headers)))
+
+(defn ok
+  ([] (response 200))
+  ([body] (response 200 body))
+  ([body headers] (response 200 body headers)))
+
+(defn created
+  ([] (response 201))
+  ([body] (response 201 body))
+  ([body headers] (response 201 body headers)))
+
+(defn accepted
+  ([] (response 202))
+  ([body] (response 202 body))
+  ([body headers] (response 202 body headers)))
+
+(defn non-authoritative
+  ([] (response 203))
+  ([body] (response 203 body))
+  ([body headers] (response 203 body headers)))
+
+(defn no-content
+  ([] (response 204))
+  ([headers] (response 204 nil headers)))
+
+(defn bad-request
+  ([] (response 400))
+  ([body] (response 400 body))
+  ([body headers] (response 400 body headers)))
+
+(defn unauthorized
+  ([] (response 401))
+  ([body] (response 401 body))
+  ([body headers] (response 401 body headers))
+  ([body headers www-authenticate]
+   (response 401 body (assoc headers "WWW-Authenticate" www-authenticate))))
+
+(defn payment-required
+  ([] (response 402))
+  ([body] (response 402 body))
+  ([body headers] (response 402 body headers)))
+
+(defn forbidden
+  ([] (response 403))
+  ([body] (response 403 body))
+  ([body headers] (response 403 body headers)))
+
+(defn not-found
+  ([] (response 404))
+  ([body] (response 404 body))
+  ([body headers] (response 404 body headers)))
+
+(defn internal-error
+  ([] (response 500))
+  ([body] (response 500 body))
+  ([body headers] (response 500 body headers)))
+
+(defn status [response] (:status response))
+(defn success? [response]
+  (let [status (status response)]
+    (and (< status 300)
+         (>= status 200))))
+(defn error? [response] (>= (status response) 400))
+
+(defn body [response] (:body response))
+(defn <-json-body [response] (utilc/<-json (:body response)))
+(defn <-json-kw-body [response] (utilc/<-json-kw (:body response)))
+
+(defn headers [response] (:headers response))

--- a/src/cljc/c3kit/wire/restc.cljc
+++ b/src/cljc/c3kit/wire/restc.cljc
@@ -66,6 +66,9 @@
   ([body] (response 500 body))
   ([body headers] (response 500 body headers)))
 
+(defn not-found-handler [request]
+  (not-found (:uri request)))
+
 (defn status [response] (:status response))
 (defn success? [response]
   (let [status (status response)]

--- a/src/cljs/c3kit/wire/rest.cljs
+++ b/src/cljs/c3kit/wire/rest.cljs
@@ -10,14 +10,18 @@
     (callback (async/<! channel)))
   nil)
 
-(defn get! [url req callback]
-  (let [channel (client/get url (restc/-maybe-update-req req))]
+(defn request! [method url request]
+  ;; [GMJ] had to extract this to make specs pass with advanced optimization for some reason...
+  (method url (restc/-maybe-update-req request)))
+
+(defn get! [url request callback]
+  (let [channel (request! client/get url request)]
     (async-callback! channel callback)))
 
-(defn post! [url req callback]
-  (let [channel (client/post url (restc/-maybe-update-req req))]
+(defn post! [url request callback]
+  (let [channel (request! client/post url request)]
     (async-callback! channel callback)))
 
-(defn put! [url req callback]
-  (let [channel (client/put url (restc/-maybe-update-req req))]
+(defn put! [url request callback]
+  (let [channel (request! client/put url request)]
     (async-callback! channel callback)))

--- a/src/cljs/c3kit/wire/rest.cljs
+++ b/src/cljs/c3kit/wire/rest.cljs
@@ -1,0 +1,23 @@
+(ns c3kit.wire.rest
+  (:require [c3kit.wire.restc :as restc]
+            [cljs-http.client :as client]
+            [cljs.core.async :refer-macros [go]]
+            [cljs.core.async :as async]))
+
+(defn- async-callback! [channel callback]
+  ;; [GMJ] `go` block is not tested because I can't get it to work with speclj
+  (go
+    (callback (async/<! channel)))
+  nil)
+
+(defn get! [url req callback]
+  (let [channel (client/get url (restc/-maybe-update-req req))]
+    (async-callback! channel callback)))
+
+(defn post! [url req callback]
+  (let [channel (client/post url (restc/-maybe-update-req req))]
+    (async-callback! channel callback)))
+
+(defn put! [url req callback]
+  (let [channel (client/put url (restc/-maybe-update-req req))]
+    (async-callback! channel callback)))


### PR DESCRIPTION
`rest.cljs` contains HTTP method functions for the browser (existing AJAX functions didn't work with REST).
`rest.cljc` contains helper functions.
`rest.clj` contains HTTP method functions for the server as well as wrappers for handlers.

The most significant refactor I did was moving `c3kit.wire.ajax/wrap-add-api-version` to `c3kit.wire.api` (and deprecate the old fn) so that I could reuse it.