### PR TITLE
Fix/websocket adapter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### 4.1.0
+ * Server-side WebSocket is no longer hard-wired to http-kit. `c3kit.wire.websocketc/create` accepts a `:transport` option — a map of `:open`, `:send!`, and `:close` fns — and `c3kit.wire.api` gains a `:ws-transport` config key that `c3kit.wire.websocket/start` threads through, so an app wiring WebSocket via `websocket/service` can run on another Ring server by calling `(api/configure! :ws-transport ...)` with an adapter. http-kit stays the default; consumers who configure nothing are unaffected.
+
 ### 4.0.1
  * `c3kit.wire.core.{ajax,rest}` now expose state-bound consumer functions: `get!`, `post!`, `put!`, `delete!`, and (ajax) `request!` operate on `default-state` and match the arities of their `c3kit.wire.{ajax,rest}` counterparts, so consumers can `(:require [c3kit.wire.core.ajax :as ajax])` and call `ajax/get!`. The state-taking primitives are now `do-get!`, `do-post!`, `do-put!`, `do-delete!`, `do-request!`. The previous `*-default!` variants are removed.
 

--- a/spec/clj/c3kit/wire/websocket_spec.clj
+++ b/spec/clj/c3kit/wire/websocket_spec.clj
@@ -1,10 +1,13 @@
 (ns c3kit.wire.websocket-spec
   (:require
+    [c3kit.apron.app :as app]
     [c3kit.apron.log :as log]
     [c3kit.wire.api :as api]
     [c3kit.wire.flashc :as flashc]
     [c3kit.wire.websocket :as sut]
+    [c3kit.wire.websocketc :as wsc]
     [speclj.core :refer :all]
+    [speclj.stub :as stub]
     ))
 
 (defn on-close-foo [{:keys [connection-id]}] {:foo connection-id})
@@ -13,7 +16,7 @@
 (describe "websocket"
 
   (with-stubs)
-  (before (api/configure! :ws-handlers nil :version "123")
+  (before (api/configure! :ws-handlers nil :ws-transport nil :version "123")
           (sut/development!))
   (around [it] (log/capture-logs (it)))
 
@@ -48,6 +51,26 @@
       (should= "123" (:version response))))
 
 
+
+  (context "service"
+
+    (around [it] (with-redefs [app/development? (stub :development? {:return false})
+                              wsc/create        (stub :wsc/create {:return :a-server})]
+                   (it)))
+
+    (it "start with default transport"
+      (let [app (sut/start {})]
+        (should= :a-server (:ws/server app))
+        (should= [sut/message-handler] (stub/last-invocation-of :wsc/create))))
+
+    (it "start with configured transport"
+      (let [transport {:open :a-open :send! :a-send :close :a-close}]
+        (api/configure! :ws-transport transport)
+        (sut/start {})
+        (should= [sut/message-handler :transport transport] (stub/last-invocation-of :wsc/create))))
+
+    (it "stop removes the server"
+      (should-not-contain :ws/server (sut/stop {:ws/server :a-server}))))
 
   ;(it "handles :ws/close"
   ;  (with-redefs [ws/dispatch-closed-connection (stub :dispatch-closed-connection {:return {}})

--- a/spec/cljc/c3kit/wire/websocketc_spec.cljc
+++ b/spec/cljc/c3kit/wire/websocketc_spec.cljc
@@ -4,7 +4,6 @@
    [speclj.core #?(:clj :refer :cljs :refer-macros)
     [context describe it should= should-contain should-not-contain should-throw should with-stubs stub with
      before should-have-invoked should-not-have-invoked should-not-throw around should-not= should-be-a]]
-   #?(:clj [org.httpkit.server :as httpkit])
    [c3kit.apron.corec :as ccc]
    [c3kit.apron.log :as log #?(:clj :refer :cljs :refer-macros) [capture-logs]]
    [c3kit.apron.time :as time :refer [seconds ago]]
@@ -34,12 +33,15 @@
   (with-stubs)
   (with now (time/now))
   (stub-now @now)
-  (with state (sut/create (stub :message-handler {:invoke (fn [_] @message-handler-result)})))
+  (with state (sut/create (stub :message-handler {:invoke (fn [_] @message-handler-result)})
+                          #?@(:clj [:transport {:open  (stub :httpkit/as-channel {:return :channel})
+                                               :send! (stub :socket/send! {:invoke (fn [& _] @send!-result)})
+                                               :close (stub :httpkit/close)}])))
   #?(:clj (with request {:params {:connection-id "client-123" :ws-csrf-token "csrf-blah"} :session/key "csrf-blah"}))
   (around [it]
     (with-redefs [sut/-create-timeout!                           (stub :sut/create-timeout {:return :fake-timeout})
                   sut/-cancel-timeout!                           (stub :sut/cancel-timeout)
-                  #?(:clj httpkit/send! :cljs sut/-socket-send!) (stub :socket/send! {:invoke (fn [& _] @send!-result)})
+                  #?(:cljs sut/-socket-send!) #?(:cljs (stub :socket/send! {:invoke (fn [& _] @send!-result)}))
                   #?(:cljs js/setTimeout) #?(:cljs (stub :js/setTimeout {:return :fake-timeout}))
                   #?(:clj sut/-schedule-with-delay) #?(:clj      (stub :-schedule-with-delay {:return :fake-delay-task}))
                   #?(:clj sut/-new-scheduler) #?(:clj            (stub :-new-scheduler {:return :fake-scheduler}))]
@@ -147,6 +149,12 @@
     (it "on-data"
       (should= nil (:on-data @@state))
       (should= "on-data" (:on-data @(sut/create :blah :on-data "on-data"))))
+
+    #?(:clj
+       (it "transport"
+         (should= sut/default-transport (:transport @(sut/create :blah)))
+         (let [transport {:open :a-open :send! :a-send :close :a-close}]
+           (should= transport (:transport @(sut/create :blah :transport transport))))))
 
     (it "atom-fn"
       (let [state (sut/create :blah :atom-fn #(atom (assoc % :foo :bar)))]
@@ -425,7 +433,6 @@
      (context "server"
 
        (with request {:params {:connection-id "client-123" :ws-csrf-token "csrf-blah"} :session/key "csrf-blah"})
-       (around [it] (with-redefs [httpkit/send! (stub :httpkit/send! {:invoke (fn [& _] @send!-result)})] (it)))
        (before (reset! message-handler-result nil)
                (reset! send!-result true))
 
@@ -445,24 +452,22 @@
              (should= "Invalid connection id" (:body response))))
 
          (it "socket response"
-           (with-redefs [httpkit/as-channel (stub :httpkit/as-channel {:return :channel})]
-             (let [response (sut/handler @state @request)
-                   [ch-request options] (stub/last-invocation-of :httpkit/as-channel)]
-               (should= :channel response)
-               (should= @request ch-request)
-               ;(should-contain :init options)
-               (should-contain :on-receive options)
-               ;(should-contain :on-ping options)
-               (should-contain :on-close options)
-               (should-contain :on-open options))))
+           (let [response (sut/handler @state @request)
+                 [ch-request options] (stub/last-invocation-of :httpkit/as-channel)]
+             (should= :channel response)
+             (should= @request ch-request)
+             ;(should-contain :init options)
+             (should-contain :on-receive options)
+             ;(should-contain :on-ping options)
+             (should-contain :on-close options)
+             (should-contain :on-open options)))
 
          (it "socket response with read-csrf option"
-           (with-redefs [httpkit/as-channel (stub :httpkit/as-channel {:return :channel})]
-             (let [request  (-> @request
-                                (assoc-in [:foo :bar] "custom-csrf")
-                                (assoc-in [:params :ws-csrf-token] "custom-csrf"))
-                   response (sut/handler @state request {:read-csrf (comp :bar :foo)})]
-               (should= :channel response))))
+           (let [request  (-> @request
+                              (assoc-in [:foo :bar] "custom-csrf")
+                              (assoc-in [:params :ws-csrf-token] "custom-csrf"))
+                 response (sut/handler @state request {:read-csrf (comp :bar :foo)})]
+             (should= :channel response)))
          )
 
        (context "on-open"
@@ -482,8 +487,8 @@
 
          (it "says hello to client"
            (sut/-open-connection! @state @request "conn-abc" "a-socket")
-           (should-have-invoked :httpkit/send!)
-           (let [[socket message-str] (stub/last-invocation-of :httpkit/send!)
+           (should-have-invoked :socket/send!)
+           (let [[socket message-str] (stub/last-invocation-of :socket/send!)
                  message (sut/unpack message-str)]
              (should= "a-socket" socket)
              (should= :ws/hello (:kind message))))
@@ -506,8 +511,6 @@
          )
 
        (context "close"
-
-         (around [it] (with-redefs [httpkit/close (stub :httpkit/close)] (it)))
 
          (it "missing socket"
            (should-not-throw (sut/close! @state "blah"))

--- a/src/clj/c3kit/wire/api.clj
+++ b/src/clj/c3kit/wire/api.clj
@@ -8,9 +8,10 @@
 (def default-error-message "Our apologies. An error occurred and we have been notified.")
 
 (def default-config {
-                     :ajax-on-ex  'c3kit.wire.ajax/default-ajax-ex-handler ;; (fn [request e])
-                     :version     "undefined"
-                     :ws-handlers nil
+                     :ajax-on-ex   'c3kit.wire.ajax/default-ajax-ex-handler ;; (fn [request e])
+                     :version      "undefined"
+                     :ws-handlers  nil
+                     :ws-transport nil
                      })
 
 (def config (atom default-config))

--- a/src/clj/c3kit/wire/websocket.clj
+++ b/src/clj/c3kit/wire/websocket.clj
@@ -112,8 +112,11 @@
 (defn start [app]
   (log/report "Starting websocket")
   (when (app/development?) (development!))
-  (let [handler (if (app/development?) (refresh-handler) message-handler)
-        server  (wsc/create handler)]
+  (let [handler   (if (app/development?) (refresh-handler) message-handler)
+        transport (:ws-transport @api/config)
+        server    (if transport
+                    (wsc/create handler :transport transport)
+                    (wsc/create handler))]
     (assoc app :ws/server server)))
 
 (defn stop [app]

--- a/src/cljc/c3kit/wire/websocketc.cljc
+++ b/src/cljc/c3kit/wire/websocketc.cljc
@@ -36,6 +36,20 @@
 (defn unpack [data] (try (util/<-edn data) (catch #?(:clj Exception :cljs :default) _ data)))
 (defn pack [message] (util/->edn message))
 
+#?(:clj
+   (def default-transport
+     "The server-side websocket transport wire depends on. A map of three fns,
+     defaulting to http-kit. Supply your own via the :transport option to create
+     to run on another Ring server.
+
+     :open  - (fn [request callbacks]) opens a socket from a ring request; callbacks
+              is {:on-receive :on-close :on-open}. Returns the ring response.
+     :send! - (fn [socket data]) sends data on the socket. Returns truthy on success.
+     :close - (fn [socket]) closes the socket."
+     {:open  httpkit/as-channel
+      :send! httpkit/send!
+      :close httpkit/close}))
+
 (declare send-to!)
 (declare call!)
 (declare ^:private connections)
@@ -158,8 +172,9 @@
        false)
 
      (defn- send-to! [server connection socket message]
-       (let [connection-id (:id @connection)]
-         (if (httpkit/send! socket (pack message))
+       (let [connection-id (:id @connection)
+             send!         (-> @server :transport :send!)]
+         (if (send! socket (pack message))
            true
            (handle-failed-send! server connection-id))))
 
@@ -285,7 +300,8 @@
         server     (merge default-options
                           (select-keys options (keys default-options))
                           #?(:clj  {:connections {}
-                                    :scheduler   (-new-scheduler)}
+                                    :scheduler   (-new-scheduler)
+                                    :transport   (:transport options default-transport)}
                              :cljs {:connection nil})
                           {:message-handler message-handler})
         state-atom (atom-fn server)]
@@ -306,13 +322,14 @@
       (let [connection-id (-> request :params :connection-id)]
         (or (maybe-invalid-csrf-token request options)
             (maybe-invalid-connection-id connection-id)
-            (httpkit/as-channel request {:on-receive (partial -data-received server connection-id)
-                                         :on-close   (partial -channel-on-close server connection-id)
-                                         :on-open    (partial -open-connection! server request connection-id)
-                                         ;; Maybe delete the two below.  They don't seem used.
-                                         ;:init       (partial -channel-init server connection-id)
-                                         ;:on-ping    (partial -channel-on-ping server connection-id)
-                                         })))))
+            (let [open (-> @server :transport :open)]
+              (open request {:on-receive (partial -data-received server connection-id)
+                             :on-close   (partial -channel-on-close server connection-id)
+                             :on-open    (partial -open-connection! server request connection-id)
+                             ;; Maybe delete the two below.  They don't seem used.
+                             ;:init       (partial -channel-init server connection-id)
+                             ;:on-ping    (partial -channel-on-ping server connection-id)
+                             }))))))
    :cljs
    (defn connect!
      "Open a websocket connection to the server.
@@ -357,7 +374,7 @@
      "Close the connection with connection-id"
      [state connection-id]
      (if-let [socket (get-in @state [:connections connection-id :socket])]
-       (httpkit/close socket)
+       ((-> @state :transport :close) socket)
        (log/warn "websocket: attempt to close missing socket: " connection-id)))
    :cljs
    (defn close!


### PR DESCRIPTION
Closes #10 

## Summary

Wire's server-side WebSocket transport was hard-wired to http-kit's server API (`org.httpkit.server`), so a Ring app using `websocket/service` **could not run on another Ring server** (Jetty, Undertow, …) without WebSocket silently failing — HTTP is correctly inverted on the Ring abstraction, but WebSocket depended on a concrete server. A DIP violation in a core module.

This introduces a small transport seam and threads it through to the public service API, with http-kit as the unchanged default.

- **`c3kit.wire.websocketc`** now depends on a `:transport` — a map of three fns (`:open`, `:send!`, `:close`) — instead of calling `httpkit/*` inline. `default-transport` binds those to http-kit, so the seam's default is byte-for-byte the old behavior. `create` accepts a `:transport` option to override it.
- **`c3kit.wire.api`** gains a `:ws-transport` config key (defaults to `nil`).
- **`c3kit.wire.websocket/start`** sources `:ws-transport` from `api/config` (the same way `:ws-handlers` is sourced) and passes it to `create` only when set — so the public `websocket/service` path can supply a transport, not just direct `create` callers.

http-kit stays a dependency and the default — this makes the module extensible rather than dead-ended; it does not remove http-kit. No public fn signatures change; the only additions are one nil-default config key and one `create` option.

**For consumers:** doing nothing behaves identically. To run on another Ring server, add `(api/configure! :ws-transport my-transport)` and supply an adapter:

```
:open  - (fn [request callbacks]) opens a socket from a ring request;
         callbacks is {:on-receive :on-close :on-open}. Returns the ring response.
:send! - (fn [socket data]) sends data on the socket. Returns truthy on success.
:close - (fn [socket]) closes the socket.
```

The contract reflects http-kit's imperative `as-channel` shape (`:open` returns a response; the socket arrives via `:on-open`). Adapters for return-a-listener servers (e.g. Ring 1.11 `ring.websocket`) absorb that impedance internally.

## Test plan

- [x] `clj -M:test:spec` passes — 395 examples, 0 failures
- [x] `clj -M:test:cljs once` passes 
- [x] `clj -M:test:react:cljs once` — ClojureScript compiles, specs pass (734 examples, 0 failures). 
- [x] `CHANGES.md` updated 
- [x] Docstrings updated — `default-transport` carries the transport contract
