### PR TITLE
Service Worker library: secure-by-default offline caching for c3kit.wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,46 @@ CLOJARS_PASSWORD=<your deploy key>
 `clj -T:build deploy` cleans, builds both jars, and pushes them to Clojars.
 `clj -T:build jar` builds without deploying. Both jars share the same VERSION.
 
+## Service Worker (offline caching)
+
+Two namespaces: `c3kit.wire.service-worker` runs inside the service worker
+(`ServiceWorkerGlobalScope`); `c3kit.wire.service-worker-register` runs on the page.
+Caching is secure by default (same-origin, `ok`, non-opaque, non-`no-store`,
+non-credentialed, GET-only).
+
+Your service worker entry (compiled to `/service-worker.js`):
+
+```clojure
+(ns my-app.service-worker
+  (:require [c3kit.wire.service-worker :as sw]))
+
+(defn -main []
+  (sw/precache! ["/" "/css/app.css" "/img/logo.png"] (str "shell-" my-app/version))
+  (sw/register-route! #"/img/"  (sw/cache-first {:cache "images"}))
+  (sw/register-route! #"/api/"  (sw/network-first {:cache "api"}))
+  (sw/register-route! "/"       (sw/stale-while-revalidate {:cache "pages"}))
+  (sw/set-default!              (sw/network-only {}))
+  (sw/start!))
+```
+
+On the page:
+
+```clojure
+(ns my-app.main
+  (:require [c3kit.wire.service-worker-register :as swr]))
+
+(swr/register! {:url "/service-worker.js"
+                :on-update (fn [_] (js/console.log "update available"))})
+```
+
+Embed your app version in cache names (e.g. `(str "shell-" version)`) to get
+automatic purge of prior-deploy caches on `activate`.
+
+**stale-while-revalidate caveat:** background revalidation is fire-and-forget and is
+not wrapped in `event.waitUntil`, so a browser may terminate the service worker before
+the refresh completes. The next request still serves the prior cached value and
+re-triggers revalidation. For must-refresh resources prefer `network-first`.
+
 # License
 
 [MIT](LICENSE) © Clean Coders.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ are stripped from `Request` objects in `ServiceWorkerGlobalScope`). If your app 
 cookie-session authentication without `Authorization` headers, you must route those
 endpoints explicitly to `network-only` or omit caching for them.
 
+Strategies available inside the service worker: `cache-first`, `network-first`,
+`stale-while-revalidate`, `cache-only`, `network-only`. Each is a factory — call
+it with an opts map, register the result as a route handler.
+
 Your service worker entry (compiled to `/service-worker.js`):
 
 ```clojure
@@ -137,6 +141,7 @@ Your service worker entry (compiled to `/service-worker.js`):
   (sw/register-route! #"/img/"  (sw/cache-first {:cache "images"}))
   (sw/register-route! #"/api/"  (sw/network-first {:cache "api"}))
   (sw/register-route! "/"       (sw/stale-while-revalidate {:cache "pages"}))
+  (sw/register-route! #"/static/" (sw/cache-only {:cache "static"}))
   (sw/set-default!              (sw/network-only {}))
   (sw/start!))
 ```
@@ -149,6 +154,9 @@ On the page:
 
 (swr/register! {:url "/service-worker.js"
                 :on-update (fn [_] (js/console.log "update available"))})
+
+;; To remove the service worker (e.g. when rolling back):
+(swr/unregister!)
 ```
 
 Embed your app version in cache names (e.g. `(str "shell-" version)`) to get
@@ -158,6 +166,18 @@ automatic purge of prior-deploy caches on `activate`.
 not wrapped in `event.waitUntil`, so a browser may terminate the service worker before
 the refresh completes. The next request still serves the prior cached value and
 re-triggers revalidation. For must-refresh resources prefer `network-first`.
+
+**precache! atomicity:** URLs passed to `precache!` are handed to `cache.addAll`, which
+is atomic — if any single URL returns a 4xx/5xx or network-fails, the entire install
+fails and the service worker never activates. Every URL must be an absolute or
+same-origin path that resolves successfully at install time.
+
+**Security footguns — `:allow-cross-origin` and `:cache-credentialed`:** these opts
+are explicit opt-outs of the secure-by-default caching gate. Use them only with a
+tight matcher (exact host + path, narrow regexp) that covers exactly the resources
+you intend to cache. A broad matcher (e.g. `(fn [_] true)`) with either opt enabled
+can cause the cache to store attacker-influenced cross-origin responses or per-user
+credentialed responses, potentially leaking private data across sessions.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,17 @@ CLOJARS_PASSWORD=<your deploy key>
 
 Two namespaces: `c3kit.wire.service-worker` runs inside the service worker
 (`ServiceWorkerGlobalScope`); `c3kit.wire.service-worker-register` runs on the page.
-Caching is secure by default (same-origin, `ok`, non-opaque, non-`no-store`,
-non-credentialed, GET-only).
+Caching is secure by default: same-origin, `ok`, non-opaque, GET-only, with hard
+blocks on `Cache-Control: no-store/no-cache/private`, `Vary: */Cookie/Authorization`,
+and `Set-Cookie` responses. Credentials are detected via `Authorization` header or
+`credentials: "include"` and are blocked by default.
+
+**Security note — threat-model limitation:** the hard blocks cover `Authorization`-header
+and `credentials: "include"` auth as well as `Vary`/`Set-Cookie`/`private`/`no-cache`
+responses. However, the service worker **cannot inspect same-origin cookie headers** (they
+are stripped from `Request` objects in `ServiceWorkerGlobalScope`). If your app uses
+cookie-session authentication without `Authorization` headers, you must route those
+endpoints explicitly to `network-only` or omit caching for them.
 
 Your service worker entry (compiled to `/service-worker.js`):
 

--- a/docs/superpowers/plans/2026-06-24-service-worker.md
+++ b/docs/superpowers/plans/2026-06-24-service-worker.md
@@ -1,0 +1,1131 @@
+# Service Worker Library Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a secure-by-default, SOLID, test-first ClojureScript service-worker library for `c3kit.wire` providing offline-read caching (precache + 5 configurable per-route strategies) and page-side registration.
+
+**Architecture:** Three namespaces split by JS execution scope: SW-global (`service-worker`), window (`service-worker-register`), and shipped test fakes (`service-worker-fake`). All SW handlers take an injected `ctx` ({:caches :fetch :scope}) — never read globals directly (DIP). Production strategies **never construct `js/Promise`**; they only `.then`/`.catch` on the thenables returned by the injected `caches`/`fetch`. In production those are real promises; in tests the fakes return a synchronous-promise double, so specs resolve synchronously with no async-test harness.
+
+**Tech Stack:** ClojureScript, Speclj, `c3kit.apron.log`, `c3kit.wire.js` (`add-listener`). No new dependencies.
+
+## Global Constraints
+
+- No new dependencies; library stays `apron`-only and never requires `c3kit.bucket`.
+- Secure by default: all cache writes gated by a single shared `cacheable?` predicate (same-origin, `response.ok`, not opaque, not `no-store`, not credentialed, GET-only) unless explicitly opted in via `:allow-cross-origin` / `:cache-credentialed`.
+- DIP: SW handlers depend on injected `ctx` {:caches :fetch :scope}; production wires real globals, tests wire fakes. No global reads inside logic.
+- Strategy contract (LSP): every strategy is `(fn [ctx request] -> thenable<Response>)`.
+- Production SW code constructs no `js/Promise` — only chains `.then`/`.catch` on injected thenables (keeps tests synchronous).
+- TDD: red-green-refactor, failing test first, behavior assertions only (what got cached / what response returned), never seam assertions.
+- Run cljs specs: `clj -M:test:cljs once`
+- Commits: `git commit --no-gpg-sign` (no signing). No Claude attribution. `feat:` prefix.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/cljs/c3kit/wire/service_worker_fake.cljs` | Sync-promise double + in-memory `caches`/`cache`/request/response/scope fakes + `fake-fetch` + `->ctx`. Shipped in src for app reuse. |
+| `src/cljs/c3kit/wire/service_worker.cljs` | `cacheable?` + cache helpers + 5 strategies + route registry + lifecycle (`install`/`activate`/`handle-fetch`/`start!`). |
+| `src/cljs/c3kit/wire/service_worker_register.cljs` | Page-side `register!`/`register-with`/`unregister!`. |
+| `spec/cljs/c3kit/wire/service_worker_spec.cljs` | Specs for fakes, security, strategies, registry, lifecycle. |
+| `spec/cljs/c3kit/wire/service_worker_register_spec.cljs` | Specs for page registration. |
+
+---
+
+### Task 1: Test fakes + synchronous-promise double
+
+**Files:**
+- Create: `src/cljs/c3kit/wire/service_worker_fake.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs`
+
+**Interfaces:**
+- Produces:
+  - `(->resolved v) -> thenable` / `(->rejected err) -> thenable` — synchronous promise double; `.then`/`.catch` fire immediately, transform + flatten.
+  - `(->headers m) -> #js{get}`; `(->request url opts?) -> req`; `(->response body opts?) -> resp` (opts `{:ok :type :status :headers}`, defaults ok=true type="basic" status=200; `clone` returns a fresh copy).
+  - `(->cache) -> fake Cache` (match/put/addAll/keys/delete, `__store` atom).
+  - `(->caches) -> fake CacheStorage` (open/keys/has/delete, `__caches` atom).
+  - `(->scope opts?) -> fake self` (`location.origin` default "https://app.test", `skipWaiting`, `clients.claim`, `addEventListener`).
+  - `(fake-fetch resp-or-fn) -> (fn [request] -> thenable)`; pass `:reject` (or a fn returning `:reject`) to simulate network failure.
+  - `(->ctx overrides?) -> {:caches :fetch :scope}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```clojure
+(ns c3kit.wire.service-worker-spec
+  (:require-macros [speclj.core :refer [context describe it should should= should-be-nil should-not should-contain]])
+  (:require [c3kit.wire.service-worker-fake :as fake]
+            [speclj.core]))
+
+(defn resolved-value [thenable]
+  (let [out (atom ::none)]
+    (.then thenable #(reset! out %))
+    @out))
+
+(describe "Service Worker fakes"
+  (it "->resolved fires then synchronously and transforms"
+    (should= 2 (resolved-value (.then (fake/->resolved 1) inc))))
+
+  (it "->resolved flattens a returned thenable"
+    (should= 3 (resolved-value (.then (fake/->resolved 1) (fn [_] (fake/->resolved 3))))))
+
+  (it "->rejected skips then and is recovered by catch"
+    (let [err (js/Error. "boom")]
+      (should= :recovered (resolved-value (.catch (fake/->rejected err) (fn [_] :recovered))))))
+
+  (it "fake cache stores and matches by request url"
+    (let [cache (fake/->cache)
+          req   (fake/->request "https://app.test/a")
+          resp  (fake/->response "body")]
+      (.put cache req resp)
+      (should= resp (resolved-value (.match cache req)))))
+
+  (it "fake cache addAll records urls"
+    (let [cache (fake/->cache)]
+      (.addAll cache #js ["https://app.test/x"])
+      (should-contain "https://app.test/x" (resolved-value (.keys cache)))))
+
+  (it "fake caches opens named caches and lists/deletes them"
+    (let [caches (fake/->caches)]
+      (.open caches "one")
+      (should-contain "one" (resolved-value (.keys caches)))
+      (should= true (resolved-value (.delete caches "one")))
+      (should-not (resolved-value (.has caches "one")))))
+
+  (it "fake-fetch resolves a response and can reject"
+    (let [req (fake/->request "https://app.test/a")]
+      (should= "ok" (.-body (resolved-value ((fake/fake-fetch (fake/->response "ok")) req))))
+      (let [caught (atom nil)]
+        (.catch ((fake/fake-fetch :reject) req) #(reset! caught %))
+        (should= true (instance? js/Error @caught))))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `c3kit.wire.service-worker-fake` namespace does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```clojure
+(ns c3kit.wire.service-worker-fake
+  "In-memory test doubles for service-worker specs. Shipped in src so apps that
+   build their own SW config can reuse them. Includes a synchronous promise double
+   so SW handlers (which only chain .then/.catch on injected thenables) resolve
+   synchronously under test.")
+
+(declare ->resolved)
+
+(defn ->rejected [err]
+  (js-obj
+    "then"  (fn [_] (->rejected err))
+    "catch" (fn [f] (->resolved (f err)))))
+
+(defn ->resolved [v]
+  (if (and v (fn? (unchecked-get v "then")))
+    v
+    (js-obj
+      "then"  (fn [f] (try (->resolved (f v)) (catch :default e (->rejected e))))
+      "catch" (fn [_] (->resolved v)))))
+
+(defn ->headers [m]
+  (let [m (or m {})]
+    (js-obj "get" (fn [k] (get m k)))))
+
+(defn ->request [url & [{:keys [method headers credentials] :or {method "GET"}}]]
+  (js-obj "url" url "method" method "credentials" credentials "headers" (->headers headers)))
+
+(defn ->response [body & [opts]]
+  (let [{:keys [ok type status headers] :or {ok true type "basic" status 200}} opts]
+    (js-obj "ok" ok "type" type "status" status "body" body
+            "headers" (->headers headers)
+            "clone" (fn [] (->response body opts)))))
+
+(defn- req-url [r] (if (string? r) r (unchecked-get r "url")))
+
+(defn ->cache []
+  (let [store (atom {})]
+    (js-obj
+      "match"  (fn [request] (->resolved (get @store (req-url request))))
+      "put"    (fn [request response] (swap! store assoc (req-url request) response) (->resolved nil))
+      "addAll" (fn [urls] (doseq [u (js->clj urls)] (swap! store assoc u :precached)) (->resolved nil))
+      "keys"   (fn [] (->resolved (clj->js (keys @store))))
+      "delete" (fn [request]
+                 (let [k (req-url request) had (contains? @store k)]
+                   (swap! store dissoc k) (->resolved had)))
+      "__store" store)))
+
+(defn ->caches []
+  (let [caches (atom {})]
+    (js-obj
+      "open"   (fn [name]
+                 (when-not (contains? @caches name) (swap! caches assoc name (->cache)))
+                 (->resolved (get @caches name)))
+      "keys"   (fn [] (->resolved (clj->js (keys @caches))))
+      "has"    (fn [name] (->resolved (contains? @caches name)))
+      "delete" (fn [name]
+                 (let [had (contains? @caches name)]
+                   (swap! caches dissoc name) (->resolved had)))
+      "__caches" caches)))
+
+(defn ->scope [& [{:keys [origin] :or {origin "https://app.test"}}]]
+  (js-obj
+    "location"         (js-obj "origin" origin)
+    "skipWaiting"      (fn [])
+    "clients"          (js-obj "claim" (fn [] (->resolved nil)))
+    "addEventListener" (fn [_ _])))
+
+(defn fake-fetch [resp-or-fn]
+  (fn [request]
+    (let [r (if (fn? resp-or-fn) (resp-or-fn request) resp-or-fn)]
+      (if (= :reject r) (->rejected (js/Error. "network fail")) (->resolved r)))))
+
+(defn ->ctx [& [{:keys [caches fetch scope]}]]
+  {:caches (or caches (->caches))
+   :fetch  (or fetch (fake-fetch (->response "ok")))
+   :scope  (or scope (->scope))})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (8 examples in "Service Worker fakes").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker_fake.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add service-worker test fakes with sync-promise double"
+```
+
+---
+
+### Task 2: Security predicate `cacheable?`
+
+**Files:**
+- Create: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Consumes: `fake/->ctx`, `fake/->request`, `fake/->response`.
+- Produces: `(cacheable? ctx request response opts) -> boolean`. True only when: method GET, `response.ok`, type not opaque/opaqueredirect, no `Cache-Control: no-store`, same-origin (or `:allow-cross-origin`), not credentialed (or `:cache-credentialed`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/cljs/c3kit/wire/service_worker_spec.cljs` (add `[c3kit.wire.service-worker :as sut]` to the `:require`):
+
+```clojure
+(describe "cacheable?"
+  (let [ctx (fake/->ctx {:scope (fake/->scope {:origin "https://app.test"})})
+        get-req (fake/->request "https://app.test/img.png")
+        ok-resp (fake/->response "x")]
+
+    (it "true for same-origin ok GET"
+      (should= true (sut/cacheable? ctx get-req ok-resp {})))
+
+    (it "false for non-GET"
+      (should= false (sut/cacheable? ctx (fake/->request "https://app.test/x" {:method "POST"}) ok-resp {})))
+
+    (it "false for non-ok response"
+      (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:ok false}) {})))
+
+    (it "false for opaque response"
+      (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:type "opaque"}) {})))
+
+    (it "false for no-store response"
+      (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:headers {"Cache-Control" "no-store"}}) {})))
+
+    (it "false for cross-origin by default, true when allowed"
+      (let [x (fake/->request "https://cdn.other/x.png")]
+        (should= false (sut/cacheable? ctx x ok-resp {}))
+        (should= true  (sut/cacheable? ctx x ok-resp {:allow-cross-origin true}))))
+
+    (it "false for credentialed by default, true when allowed"
+      (let [c (fake/->request "https://app.test/x" {:credentials "include"})
+            a (fake/->request "https://app.test/x" {:headers {"Authorization" "Bearer t"}})]
+        (should= false (sut/cacheable? ctx c ok-resp {}))
+        (should= false (sut/cacheable? ctx a ok-resp {}))
+        (should= true  (sut/cacheable? ctx c ok-resp {:cache-credentialed true}))))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `c3kit.wire.service-worker` does not exist / `cacheable?` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/cljs/c3kit/wire/service_worker.cljs`:
+
+```clojure
+(ns c3kit.wire.service-worker
+  "Secure-by-default offline caching for service workers. All handlers take an
+   injected ctx {:caches :fetch :scope} (DIP) and only chain .then/.catch on the
+   thenables those injected objects return — never constructing js/Promise — so the
+   same code runs async in production and synchronously under test."
+  (:require [c3kit.apron.log :as log]
+            [c3kit.wire.js :as wjs]
+            [clojure.string :as str]))
+
+;; ---- security policy -------------------------------------------------------
+
+(defn- scope-origin [ctx] (.. (:scope ctx) -location -origin))
+(defn- request-origin [request] (.-origin (js/URL. (.-url request))))
+(defn- same-origin? [ctx request] (= (scope-origin ctx) (request-origin request)))
+
+(defn- opaque? [response] (boolean (#{"opaque" "opaqueredirect"} (.-type response))))
+
+(defn- no-store? [response]
+  (boolean (some-> (.. response -headers) (.get "Cache-Control") (str/includes? "no-store"))))
+
+(defn- credentialed? [request]
+  (or (= "include" (.-credentials request))
+      (boolean (some-> (.-headers request) (.get "Authorization")))))
+
+(defn cacheable?
+  "Should this response be written to the cache? Secure by default."
+  [ctx request response opts]
+  (and (= "GET" (.-method request))
+       (boolean (.-ok response))
+       (not (opaque? response))
+       (not (no-store? response))
+       (or (:allow-cross-origin opts) (same-origin? ctx request))
+       (or (:cache-credentialed opts) (not (credentialed? request)))))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (7 examples in "cacheable?").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add secure-by-default cacheable? predicate"
+```
+
+---
+
+### Task 3: Cache helpers, fallback, and gated write
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Consumes: `cacheable?`, ctx.
+- Produces:
+  - `(->fallback opts request) -> Response` — `:fallback` (Response or `(fn [request])`) else a 503 `js/Response`.
+  - `(cache-response! ctx opts request response) -> response` — clones+puts when `cacheable?`, always returns the original response.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```clojure
+(defn store-keys [cache] (resolved-value (.keys cache)))
+(defn open-cache [ctx name] (resolved-value (.open (:caches ctx) name)))
+
+(describe "fallback + cache-response!"
+  (it "->fallback returns a 503 by default"
+    (should= 503 (.-status (sut/->fallback {} (fake/->request "https://app.test/x")))))
+
+  (it "->fallback uses a provided response"
+    (let [r (fake/->response "down" {:status 200})]
+      (should= r (sut/->fallback {:fallback r} (fake/->request "https://app.test/x")))))
+
+  (it "->fallback calls a fallback fn with the request"
+    (let [req (fake/->request "https://app.test/x")]
+      (should= req (sut/->fallback {:fallback (fn [rq] rq)} req))))
+
+  (it "cache-response! stores cacheable responses and returns the original"
+    (let [ctx (fake/->ctx)
+          req (fake/->request "https://app.test/a")
+          rsp (fake/->response "x")]
+      (should= rsp (sut/cache-response! ctx {:cache "c"} req rsp))
+      (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+  (it "cache-response! does not store non-cacheable responses"
+    (let [ctx (fake/->ctx)
+          req (fake/->request "https://app.test/a" {:method "POST"})
+          rsp (fake/->response "x")]
+      (sut/cache-response! ctx {:cache "c"} req rsp)
+      (should= [] (store-keys (open-cache ctx "c"))))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `->fallback`/`cache-response!` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/cljs/c3kit/wire/service_worker.cljs`:
+
+```clojure
+;; ---- cache helpers ---------------------------------------------------------
+
+(defn- open-cache [ctx name] (.open (:caches ctx) name))
+
+(defn- cache-match [ctx name request]
+  (.then (open-cache ctx name) (fn [cache] (.match cache request))))
+
+(defn- cache-put [ctx name request response]
+  (.then (open-cache ctx name) (fn [cache] (.put cache request response))))
+
+(defn ->fallback [opts request]
+  (let [fb (:fallback opts)]
+    (cond
+      (fn? fb)   (fb request)
+      (some? fb) fb
+      :else      (js/Response. nil #js {:status 503 :statusText "Service Unavailable"}))))
+
+(defn cache-response!
+  "Clone + cache response when the shared security policy permits. Returns response."
+  [ctx opts request response]
+  (when (cacheable? ctx request response opts)
+    (cache-put ctx (:cache opts) request (.clone response)))
+  response)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (5 examples in "fallback + cache-response!").
+
+Note: `->fallback`'s default branch constructs a real `js/Response`; the test env (headless browser / Node 18+) provides `Response`. This is the only `js/Response` construction in the library and is not on a hot thenable-chain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add cache helpers, fallback, and gated cache write"
+```
+
+---
+
+### Task 4: `cache-first` and `network-first` strategies
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Consumes: `cache-match`/`cache-response!`/`->fallback`, ctx `:fetch`.
+- Produces:
+  - `(cache-first opts) -> (fn [ctx request] -> thenable<Response>)`
+  - `(network-first opts) -> (fn [ctx request] -> thenable<Response>)`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```clojure
+(defn seed-cache! [ctx name request response]
+  (resolved-value (.then (.open (:caches ctx) name) (fn [c] (.put c request response)))))
+
+(describe "cache-first"
+  (it "returns cached response without fetching"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")
+          hit (fake/->response "cached")]
+      (seed-cache! ctx "c" req hit)
+      (should= hit (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))))
+
+  (it "fetches, caches, and returns on cache miss"
+    (let [net (fake/->response "fresh")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+          req (fake/->request "https://app.test/a")]
+      (should= net (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))
+      (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+  (it "returns fallback when miss and network fails"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")]
+      (should= 503 (.-status (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))))))
+
+(describe "network-first"
+  (it "fetches, caches, and returns when online"
+    (let [net (fake/->response "fresh")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+          req (fake/->request "https://app.test/a")]
+      (should= net (resolved-value ((sut/network-first {:cache "c"}) ctx req)))
+      (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+  (it "falls back to cache when network fails"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")
+          hit (fake/->response "cached")]
+      (seed-cache! ctx "c" req hit)
+      (should= hit (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))
+
+  (it "returns 503 fallback when network fails and no cache"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")]
+      (should= 503 (.-status (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `cache-first`/`network-first` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append:
+
+```clojure
+;; ---- caches known to the library (for activate purge) ----------------------
+
+(defonce ^:private known-caches (atom #{}))
+(defn- register-cache! [name] (when name (swap! known-caches conj name)) name)
+
+;; ---- strategies (LSP: each returns (fn [ctx request] -> thenable<Response>)) ----
+
+(defn- invoke-fetch [ctx request] ((:fetch ctx) request))
+
+(defn cache-first [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (-> (cache-match ctx (:cache opts) request)
+        (.then (fn [cached]
+                 (or cached
+                     (.then (invoke-fetch ctx request)
+                            (fn [response] (cache-response! ctx opts request response))))))
+        (.catch (fn [_] (->fallback opts request))))))
+
+(defn network-first [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (-> (invoke-fetch ctx request)
+        (.then (fn [response] (cache-response! ctx opts request response)))
+        (.catch (fn [_]
+                  (.then (cache-match ctx (:cache opts) request)
+                         (fn [cached] (or cached (->fallback opts request)))))))))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (3 cache-first + 3 network-first examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add cache-first and network-first strategies"
+```
+
+---
+
+### Task 5: `stale-while-revalidate`, `network-only`, `cache-only`
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Produces:
+  - `(stale-while-revalidate opts) -> (fn [ctx request] -> thenable<Response>)`
+  - `(network-only opts) -> (fn [ctx request] -> thenable<Response>)`
+  - `(cache-only opts) -> (fn [ctx request] -> thenable<Response>)`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```clojure
+(describe "stale-while-revalidate"
+  (it "returns cached immediately and refreshes the cache in the background"
+    (let [net (fake/->response "fresh")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+          req (fake/->request "https://app.test/a")
+          hit (fake/->response "stale")]
+      (seed-cache! ctx "c" req hit)
+      (should= hit (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req)))
+      ;; background revalidation overwrote the cache entry with the network response
+      (should= net (resolved-value (.then (.open (:caches ctx) "c") (fn [c] (.match c req)))))))
+
+  (it "awaits network on cache miss"
+    (let [net (fake/->response "fresh")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+          req (fake/->request "https://app.test/a")]
+      (should= net (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req))))))
+
+(describe "network-only"
+  (it "returns the network response and caches nothing"
+    (let [net (fake/->response "fresh")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+          req (fake/->request "https://app.test/a")]
+      (should= net (resolved-value ((sut/network-only {}) ctx req)))))
+
+  (it "returns fallback when offline"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")]
+      (should= 503 (.-status (resolved-value ((sut/network-only {}) ctx req)))))))
+
+(describe "cache-only"
+  (it "returns cached response"
+    (let [ctx (fake/->ctx)
+          req (fake/->request "https://app.test/a")
+          hit (fake/->response "cached")]
+      (seed-cache! ctx "c" req hit)
+      (should= hit (resolved-value ((sut/cache-only {:cache "c"}) ctx req)))))
+
+  (it "returns fallback on miss without hitting network"
+    (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+          req (fake/->request "https://app.test/a")]
+      (should= 503 (.-status (resolved-value ((sut/cache-only {:cache "c"}) ctx req)))))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `stale-while-revalidate`/`network-only`/`cache-only` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append:
+
+```clojure
+(defn stale-while-revalidate [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (.then (cache-match ctx (:cache opts) request)
+           (fn [cached]
+             (let [network (-> (invoke-fetch ctx request)
+                               (.then (fn [response] (cache-response! ctx opts request response)))
+                               (.catch (fn [_] (->fallback opts request))))]
+               (or cached network))))))
+
+(defn network-only [opts]
+  (fn [ctx request]
+    (.catch (invoke-fetch ctx request) (fn [_] (->fallback opts request)))))
+
+(defn cache-only [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (.then (cache-match ctx (:cache opts) request)
+           (fn [cached] (or cached (->fallback opts request))))))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (2 swr + 2 network-only + 2 cache-only examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add stale-while-revalidate, network-only, cache-only strategies"
+```
+
+---
+
+### Task 6: Route registry + precache config
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Consumes: strategies (any `(fn [ctx request])`).
+- Produces:
+  - `(reset-config!)` — clears routes, default, precache, known-caches (test/setup).
+  - `(register-route! matcher strategy) -> nil` — matcher = fn | regexp | exact-pathname string.
+  - `(set-default! strategy) -> nil`.
+  - `(match-route request) -> strategy|nil` — first match wins.
+  - `(precache! urls cache-name) -> nil` — also registers cache-name as known.
+  - `(known-cache-names) -> set`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```clojure
+(describe "route registry"
+  (before (sut/reset-config!))
+
+  (it "matches by predicate fn, first match wins"
+    (let [a (fn [_ _] :a) b (fn [_ _] :b)]
+      (sut/register-route! (fn [req] (re-find #"/a" (.-url req))) a)
+      (sut/register-route! (fn [_] true) b)
+      (should= a (sut/match-route (fake/->request "https://app.test/a")))
+      (should= b (sut/match-route (fake/->request "https://app.test/z")))))
+
+  (it "matches by regexp against url"
+    (sut/register-route! #"/api/" (fn [_ _] :api))
+    (should-not (nil? (sut/match-route (fake/->request "https://app.test/api/x"))))
+    (should-be-nil (sut/match-route (fake/->request "https://app.test/page"))))
+
+  (it "matches by exact pathname string"
+    (sut/register-route! "/exact" (fn [_ _] :exact))
+    (should-not (nil? (sut/match-route (fake/->request "https://app.test/exact"))))
+    (should-be-nil (sut/match-route (fake/->request "https://app.test/exact/more"))))
+
+  (it "returns nil when nothing matches"
+    (should-be-nil (sut/match-route (fake/->request "https://app.test/x"))))
+
+  (it "precache! and strategy caches populate known-cache-names"
+    (sut/precache! ["/"] "shell")
+    (sut/register-route! #"/img/" (sut/cache-first {:cache "images"}))
+    (should-contain "shell" (sut/known-cache-names))
+    (should-contain "images" (sut/known-cache-names))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — registry fns undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append:
+
+```clojure
+;; ---- route registry --------------------------------------------------------
+
+(defonce ^:private routes (atom []))
+(defonce ^:private default-handler (atom nil))
+(defonce ^:private precache-config (atom nil))
+
+(defn reset-config! []
+  (reset! routes [])
+  (reset! default-handler nil)
+  (reset! precache-config nil)
+  (reset! known-caches #{}))
+
+(defn- ->matcher [m]
+  (cond
+    (fn? m)      m
+    (regexp? m)  (fn [request] (boolean (re-find m (.-url request))))
+    (string? m)  (fn [request] (= m (.-pathname (js/URL. (.-url request)))))
+    :else        (throw (ex-info "invalid route matcher" {:matcher m}))))
+
+(defn register-route! [matcher strategy]
+  (swap! routes conj {:match (->matcher matcher) :handler strategy})
+  nil)
+
+(defn set-default! [strategy] (reset! default-handler strategy) nil)
+
+(defn match-route [request]
+  (some (fn [{:keys [match handler]}] (when (match request) handler)) @routes))
+
+(defn precache! [urls cache-name]
+  (register-cache! cache-name)
+  (reset! precache-config {:cache cache-name :urls (vec urls)})
+  nil)
+
+(defn known-cache-names [] @known-caches)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (5 examples in "route registry").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add SW route registry and precache config"
+```
+
+---
+
+### Task 7: Lifecycle — install, activate, fetch dispatch, start!
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_spec.cljs:append`
+
+**Interfaces:**
+- Consumes: registry, `known-cache-names`, `precache-config`, ctx, `wjs/add-listener`.
+- Produces:
+  - `(handle-fetch ctx request) -> thenable<Response>` — GET → matched route or default or network passthrough; non-GET → network passthrough.
+  - `(install ctx event)` — `skipWaiting`; if precache configured, `event.waitUntil(open+addAll)`.
+  - `(activate ctx event)` — `event.waitUntil`: delete caches not in `known-cache-names`, then `clients.claim`.
+  - `(start! ctx)` / `(start!)` — wire install/activate/fetch listeners (default ctx from globals).
+
+- [ ] **Step 1: Write the failing test**
+
+Append (uses a tiny fake event capturing `waitUntil`/`respondWith`):
+
+```clojure
+(defn ->event [] (let [a (atom {})]
+                   (js-obj "waitUntil"   (fn [p] (swap! a assoc :wait p) p)
+                           "respondWith" (fn [r] (swap! a assoc :respond r) r)
+                           "__a" a)))
+(defn event-wait [e] (:wait @(unchecked-get e "__a")))
+(defn event-respond [e] (:respond @(unchecked-get e "__a")))
+
+(describe "handle-fetch"
+  (before (sut/reset-config!))
+
+  (it "routes GET to the matching strategy"
+    (sut/register-route! (fn [_] true) (fn [_ _] (fake/->resolved (fake/->response "routed"))))
+    (should= "routed" (.-body (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a"))))))
+
+  (it "uses the default handler when no route matches"
+    (sut/set-default! (fn [_ _] (fake/->resolved (fake/->response "default"))))
+    (should= "default" (.-body (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a"))))))
+
+  (it "passes non-GET straight to the network"
+    (let [net (fake/->response "net")
+          ctx (fake/->ctx {:fetch (fake/fake-fetch net)})]
+      (should= net (resolved-value (sut/handle-fetch ctx (fake/->request "https://app.test/a" {:method "POST"})))))))
+
+(describe "install"
+  (before (sut/reset-config!))
+
+  (it "precaches configured urls and waits on it"
+    (let [ctx (fake/->ctx) e (->event)]
+      (sut/precache! ["https://app.test/shell"] "shell")
+      (sut/install ctx e)
+      (resolved-value (event-wait e))
+      (should-contain "https://app.test/shell" (store-keys (open-cache ctx "shell"))))))
+
+(describe "activate"
+  (before (sut/reset-config!))
+
+  (it "deletes caches not in the known set and keeps known ones"
+    (let [ctx (fake/->ctx) e (->event)]
+      (sut/precache! ["/"] "keep")
+      (resolved-value (.open (:caches ctx) "keep"))
+      (resolved-value (.open (:caches ctx) "stale"))
+      (sut/activate ctx e)
+      (resolved-value (event-wait e))
+      (let [names (resolved-value (.keys (:caches ctx)))]
+        (should-contain "keep" names)
+        (should-not (some #{"stale"} names))))))
+
+(describe "start!"
+  (it "registers install, activate, and fetch listeners on the scope"
+    (let [events (atom [])
+          scope  (fake/->scope)]
+      (with-redefs [wjs/add-listener (fn [_ ev _] (swap! events conj ev))]
+        (sut/start! (fake/->ctx {:scope scope}))
+        (should-contain "install" @events)
+        (should-contain "activate" @events)
+        (should-contain "fetch" @events)))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — lifecycle fns undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append:
+
+```clojure
+;; ---- lifecycle -------------------------------------------------------------
+
+(defn- network-passthrough [ctx request] (invoke-fetch ctx request))
+
+(defn handle-fetch [ctx request]
+  (if (= "GET" (.-method request))
+    (if-let [handler (or (match-route request) @default-handler)]
+      (handler ctx request)
+      (network-passthrough ctx request))
+    (network-passthrough ctx request)))
+
+(defn install [ctx event]
+  (log/info "[ServiceWorker] install")
+  (.skipWaiting (:scope ctx))
+  (when-let [{:keys [cache urls]} @precache-config]
+    (.waitUntil event
+      (.then (open-cache ctx cache) (fn [c] (.addAll c (clj->js urls)))))))
+
+(defn activate [ctx event]
+  (log/info "[ServiceWorker] activate")
+  (let [keep? (known-cache-names)]
+    (.waitUntil event
+      (-> (.keys (:caches ctx))
+          (.then (fn [names]
+                   (reduce (fn [p name]
+                             (if (keep? name)
+                               p
+                               (.then p (fn [_] (.delete (:caches ctx) name)))))
+                           (.then (.keys (:caches ctx)) (fn [_] nil))
+                           (js->clj names))))
+          (.then (fn [_] (.. (:scope ctx) -clients (claim))))))))
+
+(defn- fetch-listener [ctx event]
+  (.respondWith event (handle-fetch ctx (.-request event))))
+
+(defn ctx-from-globals []
+  {:caches js/caches
+   :fetch  (fn [request] (js/fetch request))
+   :scope  js/self})
+
+(defn start!
+  ([] (start! (ctx-from-globals)))
+  ([ctx]
+   (wjs/add-listener (:scope ctx) "install"  (fn [e] (install ctx e)))
+   (wjs/add-listener (:scope ctx) "activate" (fn [e] (activate ctx e)))
+   (wjs/add-listener (:scope ctx) "fetch"    (fn [e] (fetch-listener ctx e)))
+   nil))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (3 handle-fetch + 1 install + 1 activate + 1 start! examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs spec/cljs/c3kit/wire/service_worker_spec.cljs
+git commit --no-gpg-sign -m "feat: add SW lifecycle handlers and start! wiring"
+```
+
+---
+
+### Task 8: Page-side registration
+
+**Files:**
+- Create: `src/cljs/c3kit/wire/service_worker_register.cljs`
+- Test: `spec/cljs/c3kit/wire/service_worker_register_spec.cljs`
+
+**Interfaces:**
+- Produces:
+  - `(register-with {:container :secure? :url :on-update :on-active}) -> thenable` — testable core: no-op (resolved nil) when not secure or no container; else `container.register(url)`, wire `updatefound` → installing `statechange` → `:on-update` on "installed", `:on-active` on "activated".
+  - `(register! opts) -> thenable` — fills `:container`/`:secure?` from globals, `:url` default "/service-worker.js".
+  - `(unregister!) -> thenable`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/cljs/c3kit/wire/service_worker_register_spec.cljs`:
+
+```clojure
+(ns c3kit.wire.service-worker-register-spec
+  (:require-macros [speclj.core :refer [describe it should should= should-be-nil should-not should-contain]])
+  (:require [c3kit.wire.service-worker-fake :as fake]
+            [c3kit.wire.service-worker-register :as sut]
+            [speclj.core]))
+
+(defn ->installing [state]
+  (let [listeners (atom {})]
+    (js-obj "state" state
+            "addEventListener" (fn [ev cb] (swap! listeners assoc ev cb))
+            "__fire" (fn [ev] ((get @listeners ev))))))
+
+(defn ->registration [installing]
+  (let [listeners (atom {})]
+    (js-obj "installing" installing
+            "addEventListener" (fn [ev cb] (swap! listeners assoc ev cb))
+            "__fire" (fn [ev] ((get @listeners ev)))
+            "unregister" (fn [] (fake/->resolved true)))))
+
+(defn ->container [registration]
+  (let [calls (atom [])]
+    (js-obj "register" (fn [url] (swap! calls conj url) (fake/->resolved registration))
+            "getRegistration" (fn [] (fake/->resolved registration))
+            "__calls" calls)))
+
+(describe "service worker registration"
+  (it "no-ops when not in a secure context"
+    (let [container (->container (->registration nil))]
+      (sut/register-with {:container container :secure? false :url "/sw.js"})
+      (should= [] @(unchecked-get container "__calls"))))
+
+  (it "no-ops when no service worker container"
+    (should-be-nil (let [out (atom ::x)]
+                     (.then (sut/register-with {:container nil :secure? true :url "/sw.js"})
+                            #(reset! out %))
+                     @out)))
+
+  (it "registers the given url in a secure context"
+    (let [container (->container (->registration nil))]
+      (sut/register-with {:container container :secure? true :url "/sw.js"})
+      (should-contain "/sw.js" @(unchecked-get container "__calls"))))
+
+  (it "calls on-update when the new worker reaches installed"
+    (let [installing   (->installing "installed")
+          registration (->registration installing)
+          container    (->container registration)
+          updated      (atom nil)]
+      (sut/register-with {:container container :secure? true :url "/sw.js"
+                          :on-update (fn [reg] (reset! updated reg))})
+      ((unchecked-get registration "__fire") "updatefound")
+      ((unchecked-get installing "__fire") "statechange")
+      (should= registration @updated)))
+
+  (it "calls on-active when the new worker reaches activated"
+    (let [installing   (->installing "activated")
+          registration (->registration installing)
+          container    (->container registration)
+          active       (atom nil)]
+      (sut/register-with {:container container :secure? true :url "/sw.js"
+                          :on-active (fn [reg] (reset! active reg))})
+      ((unchecked-get registration "__fire") "updatefound")
+      ((unchecked-get installing "__fire") "statechange")
+      (should= registration @active))))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `clj -M:test:cljs once`
+Expected: FAIL — `c3kit.wire.service-worker-register` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/cljs/c3kit/wire/service_worker_register.cljs`:
+
+```clojure
+(ns c3kit.wire.service-worker-register
+  "Page-side service-worker registration. register-with takes its secure-context
+   flag and serviceWorker container as explicit args (DIP) so it is testable
+   without global redefs; register! fills them from globals."
+  (:require [c3kit.apron.log :as log]))
+
+(defn- wire-update-callbacks [registration on-update on-active]
+  (.addEventListener registration "updatefound"
+    (fn []
+      (when-let [installing (.-installing registration)]
+        (.addEventListener installing "statechange"
+          (fn []
+            (case (.-state installing)
+              "installed" (when on-update (on-update registration))
+              "activated" (when on-active (on-active registration))
+              nil)))))))
+
+(defn register-with [{:keys [container secure? url on-update on-active]
+                      :or   {url "/service-worker.js"}}]
+  (cond
+    (not secure?)
+    (do (log/warn "service worker: insecure context, skipping registration")
+        (js/Promise.resolve nil))
+
+    (nil? container)
+    (do (log/warn "service worker: unsupported, skipping registration")
+        (js/Promise.resolve nil))
+
+    :else
+    (-> (.register container url)
+        (.then (fn [registration]
+                 (wire-update-callbacks registration on-update on-active)
+                 (log/info "service worker registered:" url)
+                 registration))
+        (.catch (fn [err] (log/warn "service worker registration failed:" err) nil)))))
+
+(defn- sw-container [] (when (exists? js/navigator) (.-serviceWorker js/navigator)))
+(defn- secure-context? [] (boolean (and (exists? js/self) (.-isSecureContext js/self))))
+
+(defn register!
+  "Register the service worker. opts: {:url :on-update :on-active}."
+  [opts]
+  (register-with (merge {:container (sw-container) :secure? (secure-context?)} opts)))
+
+(defn unregister! []
+  (if-let [c (sw-container)]
+    (-> (.getRegistration c) (.then (fn [reg] (when reg (.unregister reg)))))
+    (js/Promise.resolve nil)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS (5 examples in "service worker registration").
+
+Note: `register-with`'s no-op branches construct a real `js/Promise.resolve`. The "no container" test chains `.then` on it — headless/Node env resolves it; the test reads `::x` → nil after resolve. If the env's microtask timing makes this flake, assert on `@(unchecked-get container "__calls")` being empty instead (already covered by the secure-context test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker_register.cljs spec/cljs/c3kit/wire/service_worker_register_spec.cljs
+git commit --no-gpg-sign -m "feat: add page-side service worker registration"
+```
+
+---
+
+### Task 9: Public docstrings + README usage (OSS readiness)
+
+**Files:**
+- Modify: `src/cljs/c3kit/wire/service_worker.cljs` (docstrings on public fns)
+- Modify: `README.md` (usage section)
+
+**Interfaces:** none new — documentation only.
+
+- [ ] **Step 1: Add docstrings to every public fn**
+
+Ensure each public fn in `service_worker.cljs` has a one-line docstring: `cacheable?`, `->fallback`, `cache-response!`, `cache-first`, `network-first`, `stale-while-revalidate`, `network-only`, `cache-only`, `register-route!`, `set-default!`, `match-route`, `precache!`, `known-cache-names`, `reset-config!`, `handle-fetch`, `install`, `activate`, `start!`, `ctx-from-globals`. Strategy docstrings state the cache/network order and the fallback behavior.
+
+- [ ] **Step 2: Add a README usage section**
+
+Append to `README.md`:
+
+````markdown
+## Service Worker (offline caching)
+
+Two namespaces: `c3kit.wire.service-worker` runs inside the service worker
+(`ServiceWorkerGlobalScope`); `c3kit.wire.service-worker-register` runs on the page.
+Caching is secure by default (same-origin, `ok`, non-opaque, non-`no-store`,
+non-credentialed, GET-only).
+
+Your service worker entry (compiled to `/service-worker.js`):
+
+```clojure
+(ns my-app.service-worker
+  (:require [c3kit.wire.service-worker :as sw]))
+
+(defn -main []
+  (sw/precache! ["/" "/css/app.css" "/img/logo.png"] (str "shell-" my-app/version))
+  (sw/register-route! #"/img/"  (sw/cache-first {:cache "images"}))
+  (sw/register-route! #"/api/"  (sw/network-first {:cache "api"}))
+  (sw/register-route! "/"       (sw/stale-while-revalidate {:cache "pages"}))
+  (sw/set-default!              (sw/network-only {}))
+  (sw/start!))
+```
+
+On the page:
+
+```clojure
+(ns my-app.main
+  (:require [c3kit.wire.service-worker-register :as swr]))
+
+(swr/register! {:url "/service-worker.js"
+                :on-update (fn [_] (js/console.log "update available"))})
+```
+
+Embed your app version in cache names (e.g. `(str "shell-" version)`) to get
+automatic purge of prior-deploy caches on `activate`.
+````
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `clj -M:test:cljs once`
+Expected: PASS — all service-worker examples green, no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cljs/c3kit/wire/service_worker.cljs README.md
+git commit --no-gpg-sign -m "docs: document service worker library usage and public API"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Caching/offline only, no bucket dep → Tasks 2-7, no bucket require anywhere. ✓
+- 3 namespaces split by scope → Tasks 1 (fake), 2-7 (sw), 8 (register). ✓
+- DI ctx {:caches :fetch :scope} → every handler takes ctx; `ctx-from-globals` only in Task 7. ✓
+- 5 strategies → Tasks 4-5. ✓
+- Route registry (fn/regexp/string, first-match-wins, default) → Task 6. ✓
+- Precache + activate keep-set purge → Tasks 6-7. ✓
+- Page registration with real update/active callbacks + secure-context no-op → Task 8. ✓
+- Security `cacheable?` (same-origin, ok, opaque, no-store, credentialed, GET, opt-ins) → Task 2; gating in Task 3 `cache-response!`. ✓
+- No SW-specific version (cache names app-supplied) → Tasks 6-7, README Task 9. ✓
+- Fakes shipped in src → Task 1. ✓
+- TDD throughout; behavior assertions → all tasks. ✓
+- OSS: docstrings + README → Task 9. ✓
+
+**Placeholder scan:** none — every step has full code or exact prose. ✓
+
+**Type consistency:** strategy contract `(fn [ctx request] -> thenable<Response>)` uniform across Tasks 4-7; `cache-response!` arg order `(ctx opts request response)` consistent; `precache!` arg order `(urls cache-name)` consistent in Tasks 6, 7, 9; `register-with` keys consistent Task 8. ✓
+
+**Risk note:** Two real-`js/Promise` constructions exist by necessity — `->fallback` default 503 (Task 3) and `register-with` no-op branches (Task 8). Neither is on a thenable-chain that tests assert through synchronously; both tasks carry a note with the fallback assertion if env timing differs. Everything else chains only injected thenables → synchronous specs.

--- a/docs/superpowers/specs/2026-06-24-service-worker-design.md
+++ b/docs/superpowers/specs/2026-06-24-service-worker-design.md
@@ -178,9 +178,24 @@ choices must be explicit opt-ins.
   responses are never written to a cache. Avoids cache poisoning and storing partial/error bodies.
 - **Respect `no-store`.** Responses with `Cache-Control: no-store` are not cached, even on an
   otherwise-cacheable route.
+- **Respect `no-cache` and `private`.** In addition to `no-store`, responses whose
+  `Cache-Control` directive contains `no-cache` or `private` are never cached. The check
+  tokenizes the header value (case-insensitive, split on whitespace/comma) so any of the
+  three directives blocks the write regardless of order or additional directives.
+- **Block `Vary: *`, `Vary: Cookie`, `Vary: Authorization`.** Responses that vary on a
+  wildcard or on credential-bearing headers indicate per-user content and are never cached.
+- **Block `Set-Cookie`.** A response that sets a cookie is treated as session-bearing and
+  is never cached.
 - **Don't cache credentialed/auth responses by default.** Requests carrying `Authorization`
   headers or `credentials: "include"` are treated as non-cacheable unless the route explicitly
-  opts in (`:cache-credentialed true`). Stops auth-scoped data leaking into a shared cache.
+  opts in (`:cache-credentialed true`).
+- **Threat-model limitation.** The above blocks cover `Authorization`-header auth and
+  `credentials: "include"` auth, plus response-side signals (`Vary`, `Set-Cookie`,
+  `Cache-Control: private/no-cache`). They do NOT auto-detect same-origin cookie auth:
+  service workers cannot inspect same-origin `Cookie` request headers (the browser strips
+  them from `Request` objects inside `ServiceWorkerGlobalScope`). Apps that rely on
+  cookie-session authentication without `Authorization` headers must route those endpoints
+  to `network-only` (or omit caching) themselves.
 - **GET-only writes.** Only `GET` responses are ever cached; non-GET always passes through to
   the network. (Caching a mutation response is meaningless and risky.)
 - **Inert fallback.** The default 503 fallback carries an empty body and no headers derived from

--- a/docs/superpowers/specs/2026-06-24-service-worker-design.md
+++ b/docs/superpowers/specs/2026-06-24-service-worker-design.md
@@ -1,0 +1,174 @@
+# Service Worker Library — Design
+
+Date: 2026-06-24
+Status: Approved (design)
+
+## Purpose
+
+Provide a reusable, high-quality service-worker library for `c3kit.wire` that gives
+consuming apps **offline read** capability: precache an app shell and serve cached
+content via configurable per-route caching strategies. Scope is caching/offline only.
+Background sync of dirty entities is **out of scope** — `c3kit.bucket` already provides
+the IndexedDB layer (`idb-io`, `idb-reader`, `idbc`) and any entity-sync pipeline belongs
+to the application, not this library.
+
+No new dependencies. The library stays `apron`-only and never references `c3kit.bucket`.
+
+## Non-Goals
+
+- Background sync / entity push-on-reconnect (app concern; bucket-coupled).
+- IndexedDB access (bucket owns it).
+- Building/compiling the SW script (app owns its compile target → `/service-worker.js`).
+- A SW-specific cache-versioning scheme (rides on the app's existing version; see Cache Naming).
+
+## Architecture
+
+Three namespaces, split strictly by JavaScript execution scope. The ServiceWorker global
+scope and the window scope are different runtimes; code for one must not be pulled into the
+other's bundle.
+
+| Namespace | Scope | Responsibility |
+|---|---|---|
+| `c3kit.wire.service-worker` | `ServiceWorkerGlobalScope` | strategies, route registry, lifecycle handlers, precache |
+| `c3kit.wire.service-worker-register` | window / page | register the SW, drive the update lifecycle |
+| `c3kit.wire.service-worker-fake` | test (shipped in `src/cljs`) | in-memory `FakeCacheStorage`/`FakeCache`/fake-fetch for behavior tests |
+
+The fakes ship in `src/` (not `spec/`) so apps that build their own SW config get them for
+free — mirroring how wire already ships `spec_helper.cljs` in `src`.
+
+## Dependency Injection (the test seam)
+
+Every handler receives an explicit **context** map. No global reads inside logic, no
+passthrough stub namespace (wilson's `js-core` smell), no `set!`-ing globals in tests.
+
+```clojure
+{:caches js/caches   ; injectable; defaults to the real global
+ :fetch  js/fetch
+ :scope  js/self}
+```
+
+Tests pass `service-worker-fake` doubles in `ctx`. Assertions are about observable
+behavior — what ended up cached, what `Response` came back — not which wrapper was called.
+
+## Async Style
+
+Native promise interop via a tiny internal helper (`then`, `catch`, `resolved`). SW APIs
+(`respondWith`, `waitUntil`, `caches.*`, `fetch`) are promise-native, so handlers return
+real `Promise`s with no conversion. No custom promise macro (wilson reimplemented one).
+
+## Caching Strategies
+
+The standard five. Each is a **constructor** returning a handler `(fn [ctx request] -> Promise<Response>)`:
+
+```clojure
+(cache-first            {:cache "images" :fallback resp-or-fn})
+(network-first          {:cache "api"    :fallback resp-or-fn})
+(stale-while-revalidate {:cache "pages"})
+(network-only           {})
+(cache-only             {:cache "shell"  :fallback resp-or-fn})
+```
+
+`opts`:
+- `:cache` — cache name (string). App names it; may embed the app version for deploy invalidation.
+- `:fallback` — optional `Response` or `(fn [request] -> Response)`. Default: a 503
+  "Service Unavailable" `Response`.
+
+Strategy semantics:
+- **cache-first** — return cached if present; else fetch, cache a clone, return; on network
+  failure return `:fallback`.
+- **network-first** — fetch, cache a clone, return; on network failure return cached, else `:fallback`.
+- **stale-while-revalidate** — return cached immediately (if present) while fetching in the
+  background to refresh the cache; if no cache, await fetch; on total failure return `:fallback`.
+- **network-only** — fetch passthrough; no caching; on failure `:fallback`.
+- **cache-only** — return cached; if absent return `:fallback`; never hits network.
+
+Only successful responses are cached (e.g. `response.ok`); error/opaque-where-inappropriate
+responses are not written, to avoid poisoning the cache.
+
+## Route Registry (predicates, first-match-wins)
+
+```clojure
+(register-route! matcher strategy)  ; matcher = predicate fn | regex | exact-path string
+(set-default!   strategy)           ; fallthrough handler; default = network passthrough
+(precache!      ["/" "/css/app.css" ...] cache-name) ; addAll into the named shell cache on install
+(reset-routes!)                     ; clears the registry (test/setup convenience)
+```
+
+- Matchers are normalized to predicates: a regex matches against the request URL/path;
+  a string matches the path exactly; a fn receives the `request`.
+- Routes are held in an atom of `[{:match pred :handler strategy}]`. First match wins.
+- Fetch with no matching route uses the default (network passthrough unless overridden).
+
+## Lifecycle Wiring
+
+```clojure
+(start! ctx)  ; wires install/activate/fetch listeners on (:scope ctx) via wjs/add-listener
+```
+
+- **install** — precache the shell list (`cache.addAll`) inside `waitUntil`; call `skipWaiting`.
+- **activate** — purge every cache **not** referenced by the current precache cache + route
+  caches (open/closed cleanup, OCP-friendly); call `clients.claim`; wrapped in `waitUntil`.
+- **fetch** — `GET` → first matching route's strategy (`respondWith`); non-`GET` → network
+  passthrough.
+
+The consuming app writes its own `service_worker.cljs` with a `-main` that calls
+`precache!` / `register-route!` / `set-default!` then `start!`. Wire ships the namespaces;
+the app owns the cljs compile target that emits `/service-worker.js`.
+
+### Known-cache set for purge
+
+`activate` computes the keep-set as: the precache cache name ∪ every `:cache` named by a
+registered route ∪ the default strategy's cache (if any). Any other cache name is deleted.
+This is how deploy invalidation works without a SW-specific version: when the app bakes its
+version into cache names, last deploy's names fall outside the new keep-set and are purged.
+
+## Page Registration
+
+```clojure
+(register! {:url "/service-worker.js" :on-update f :on-active f}) ; -> Promise<registration>
+(unregister!)                                                     ; -> Promise
+```
+
+- `register!` registers the SW, wires `updatefound` → new worker `statechange`, and invokes
+  `:on-update` (new worker installed, update available) and `:on-active` (worker activated)
+  callbacks. Surfacing real callbacks fixes wilson's log-only gap.
+- No-ops gracefully when `navigator.serviceWorker` is unavailable (returns resolved nil).
+
+## Cache Naming (no SW-specific version)
+
+The library is version-agnostic. It uses the cache names the app supplies. For
+purge-on-deploy, the app embeds its existing build version into the names it passes
+(e.g. `(str "shell-" app-version)`). The `activate` keep-set logic then drops prior-version
+caches automatically. No version field in `ctx`; no version concept inside the SW lib.
+
+## Testing (TDD, behavior over seams)
+
+Speclj specs per namespace. `service-worker-fake` provides a real in-memory `CacheStorage`
+so specs assert *what was cached* and *what response was returned*, not *which function was
+invoked*. Coverage:
+
+- Each strategy: hit/miss/network-failure → correct response + correct cache writes.
+- Route registry: matcher normalization (fn/regex/string), first-match-wins, default fallthrough.
+- Lifecycle: install precaches + skipWaiting; activate purges only non-keep caches + claims;
+  fetch routes GET vs passes through non-GET.
+- Registration: registers, wires update callbacks, no-ops without `serviceWorker`.
+
+## Improvements Over Wilson
+
+- No `js-core` passthrough stub-seam namespace — DI instead.
+- No custom `with-promise` macro — native interop helper.
+- Per-route configurable strategies (the standard five) instead of one network-first-for-all-GETs.
+- Real update/active callbacks on registration instead of log-only.
+- Cache invalidation via app-version-in-name + keep-set purge, no hardcoded literal names.
+- Reusable in-memory cache fakes shipped for app tests.
+- App-specific paths and entity-sync removed from the library boundary.
+
+## File Layout
+
+```
+src/cljs/c3kit/wire/service_worker.cljs
+src/cljs/c3kit/wire/service_worker_register.cljs
+src/cljs/c3kit/wire/service_worker_fake.cljs
+spec/cljs/c3kit/wire/service_worker_spec.cljs
+spec/cljs/c3kit/wire/service_worker_register_spec.cljs
+```

--- a/docs/superpowers/specs/2026-06-24-service-worker-design.md
+++ b/docs/superpowers/specs/2026-06-24-service-worker-design.md
@@ -3,6 +3,10 @@
 Date: 2026-06-24
 Status: Approved (design)
 
+Quality bar: this is an **open-source** library. It must be **secure by default**,
+**SOLID**, and built **test-first (TDD)**. The sections below treat those as hard
+constraints, not aspirations.
+
 ## Purpose
 
 Provide a reusable, high-quality service-worker library for `c3kit.wire` that gives
@@ -72,6 +76,11 @@ The standard five. Each is a **constructor** returning a handler `(fn [ctx reque
 - `:cache` — cache name (string). App names it; may embed the app version for deploy invalidation.
 - `:fallback` — optional `Response` or `(fn [request] -> Response)`. Default: a 503
   "Service Unavailable" `Response`.
+- `:allow-cross-origin` — opt in to caching cross-origin responses (default false; see Security).
+- `:cache-credentialed` — opt in to caching credentialed/auth responses (default false; see Security).
+
+All caching in every strategy is gated by the shared `cacheable?` predicate (Security), so the
+secure-by-default policy holds regardless of which strategy is chosen.
 
 Strategy semantics:
 - **cache-first** — return cached if present; else fetch, cache a clone, return; on network
@@ -152,6 +161,74 @@ invoked*. Coverage:
 - Lifecycle: install precaches + skipWaiting; activate purges only non-keep caches + claims;
   fetch routes GET vs passes through non-GET.
 - Registration: registers, wires update callbacks, no-ops without `serviceWorker`.
+
+## Security (secure by default)
+
+A service worker intercepts every request under its scope and persists responses on disk.
+That makes it a security-sensitive surface; the defaults must be conservative and the unsafe
+choices must be explicit opt-ins.
+
+- **Secure context only.** `register!` no-ops gracefully (resolved nil) when not in a secure
+  context (`self.isSecureContext` false). HTTPS/localhost is browser-enforced; we fail closed,
+  never throw.
+- **Same-origin caching by default.** Strategies cache only same-origin requests. Cross-origin
+  caching requires an explicit per-route opt-in (`:allow-cross-origin true`). Prevents silently
+  persisting third-party content.
+- **No opaque-response caching.** Opaque (`type` `"opaque"`/`"opaqueredirect"`) and non-`ok`
+  responses are never written to a cache. Avoids cache poisoning and storing partial/error bodies.
+- **Respect `no-store`.** Responses with `Cache-Control: no-store` are not cached, even on an
+  otherwise-cacheable route.
+- **Don't cache credentialed/auth responses by default.** Requests carrying `Authorization`
+  headers or `credentials: "include"` are treated as non-cacheable unless the route explicitly
+  opts in (`:cache-credentialed true`). Stops auth-scoped data leaking into a shared cache.
+- **GET-only writes.** Only `GET` responses are ever cached; non-GET always passes through to
+  the network. (Caching a mutation response is meaningless and risky.)
+- **Inert fallback.** The default 503 fallback carries an empty body and no headers derived from
+  the request — it leaks nothing.
+- **No dynamic code.** Routes are data + pure predicates; no `eval`, no string-compiled handlers.
+- **Body-clone discipline.** A `Response` body is single-use; strategies clone before caching so
+  the returned response is never a consumed stream.
+- **Scope is documented, not widened.** The library registers at the URL the app gives it and
+  does not broaden scope. Docs warn that SW scope controls all paths beneath it.
+
+These rules live in one place — a `cacheable?` predicate the strategies share — so the policy is
+testable in isolation and applied uniformly. Each rule gets a failing test first.
+
+## SOLID Mapping
+
+- **SRP** — one responsibility per namespace/unit: strategies, route registry, lifecycle
+  handlers, page registration, and fakes are each separate. A change to purge logic doesn't
+  touch strategy code.
+- **OCP** — adding a new strategy is a new constructor returning the same handler shape; the
+  fetch dispatch never changes. Matcher kinds extend through one normalization step, not by
+  editing the registry.
+- **LSP** — every strategy satisfies the same contract `(fn [ctx request] -> Promise<Response>)`
+  and is freely substitutable anywhere a strategy is expected.
+- **ISP** — `ctx` carries only `{:caches :fetch :scope}`; handlers receive exactly what they
+  need. No god-config object.
+- **DIP** — handlers depend on the injected `ctx` abstractions, never on `js/caches` / `js/fetch`
+  globals directly. Production wires real globals; tests wire fakes.
+
+## TDD Discipline
+
+Strict red-green-refactor. No production line without a failing spec first. The `cacheable?`
+security predicate, each strategy's hit/miss/failure path, matcher normalization, the
+activate keep-set/purge, and registration's secure-context + callback wiring each start as a
+red test. Behavior assertions only (what was cached / what response returned), never seam
+assertions.
+
+## Open-Source Readiness
+
+- **License/headers** — inherits the repo's existing license; no new third-party code, no
+  copied wilson source.
+- **Public API documented** — docstrings on every public fn; a usage section in the wire README
+  (or `docs/`) showing a minimal SW namespace + page registration.
+- **No app-specific leakage** — zero hardcoded paths, asset names, schemas, or endpoints from any
+  app. All such values are caller-supplied.
+- **No secrets, no telemetry** — the library makes no network calls of its own beyond the
+  fetches a strategy is explicitly asked to perform.
+- **Self-contained tests** — fakes ship in `src/`, so the public test surface is reusable and the
+  examples in docs are runnable.
 
 ## Improvements Over Wilson
 

--- a/spec/cljs/c3kit/wire/service_worker_register_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_register_spec.cljs
@@ -58,4 +58,15 @@
                                     :on-active (fn [reg] (reset! active reg))})
                 ((unchecked-get registration "__fire") "updatefound")
                 ((unchecked-get installing "__fire") "statechange")
-                (should= registration @active))))
+                (should= registration @active)))
+
+          (it "unregister-with calls .unregister on the live registration"
+              (let [unregistered (atom false)
+                    reg          (js-obj "unregister" (fn [] (reset! unregistered true) (fake/->resolved true)))
+                    container    (js-obj "getRegistration" (fn [] (fake/->resolved reg)))]
+                (sut/unregister-with container)
+                (should= true @unregistered)))
+
+          (it "unregister-with returns a resolved thenable when no serviceWorker container"
+              (let [result (sut/unregister-with nil)]
+                (should (fn? (unchecked-get result "then"))))))

--- a/spec/cljs/c3kit/wire/service_worker_register_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_register_spec.cljs
@@ -1,0 +1,61 @@
+(ns c3kit.wire.service-worker-register-spec
+  (:require-macros [speclj.core :refer [describe it should should= should-be-nil should-not should-contain]])
+  (:require [c3kit.wire.service-worker-fake :as fake]
+            [c3kit.wire.service-worker-register :as sut]
+            [speclj.core]))
+
+(defn ->installing [state]
+  (let [listeners (atom {})]
+    (js-obj "state" state
+            "addEventListener" (fn [ev cb] (swap! listeners assoc ev cb))
+            "__fire" (fn [ev] ((get @listeners ev))))))
+
+(defn ->registration [installing]
+  (let [listeners (atom {})]
+    (js-obj "installing" installing
+            "addEventListener" (fn [ev cb] (swap! listeners assoc ev cb))
+            "__fire" (fn [ev] ((get @listeners ev)))
+            "unregister" (fn [] (fake/->resolved true)))))
+
+(defn ->container [registration]
+  (let [calls (atom [])]
+    (js-obj "register" (fn [url] (swap! calls conj url) (fake/->resolved registration))
+            "getRegistration" (fn [] (fake/->resolved registration))
+            "__calls" calls)))
+
+(describe "service worker registration"
+          (it "no-ops when not in a secure context"
+              (let [container (->container (->registration nil))]
+                (sut/register-with {:container container :secure? false :url "/sw.js"})
+                (should= [] @(unchecked-get container "__calls"))))
+
+          (it "no-ops and returns a thenable when no service worker container"
+              (let [result (sut/register-with {:container nil :secure? true :url "/sw.js"})]
+                (should (fn? (unchecked-get result "then")))))
+
+          (it "registers the given url in a secure context"
+              (let [container (->container (->registration nil))]
+                (sut/register-with {:container container :secure? true :url "/sw.js"})
+                (should-contain "/sw.js" @(unchecked-get container "__calls"))))
+
+          (it "calls on-update when the new worker reaches installed"
+              (let [installing   (->installing "installed")
+                    registration (->registration installing)
+                    container    (->container registration)
+                    updated      (atom nil)]
+                (sut/register-with {:container container :secure? true :url "/sw.js"
+                                    :on-update (fn [reg] (reset! updated reg))})
+                ((unchecked-get registration "__fire") "updatefound")
+                ((unchecked-get installing "__fire") "statechange")
+                (should= registration @updated)))
+
+          (it "calls on-active when the new worker reaches activated"
+              (let [installing   (->installing "activated")
+                    registration (->registration installing)
+                    container    (->container registration)
+                    active       (atom nil)]
+                (sut/register-with {:container container :secure? true :url "/sw.js"
+                                    :on-active (fn [reg] (reset! active reg))})
+                ((unchecked-get registration "__fire") "updatefound")
+                ((unchecked-get installing "__fire") "statechange")
+                (should= registration @active))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -1,0 +1,46 @@
+(ns c3kit.wire.service-worker-spec
+  (:require-macros [speclj.core :refer [context describe it should should= should-be-nil should-not should-contain]])
+  (:require [c3kit.wire.service-worker-fake :as fake]
+            [speclj.core]))
+
+(defn resolved-value [thenable]
+  (let [out (atom ::none)]
+    (.then thenable #(reset! out %))
+    @out))
+
+(describe "Service Worker fakes"
+          (it "->resolved fires then synchronously and transforms"
+              (should= 2 (resolved-value (.then (fake/->resolved 1) inc))))
+
+          (it "->resolved flattens a returned thenable"
+              (should= 3 (resolved-value (.then (fake/->resolved 1) (fn [_] (fake/->resolved 3))))))
+
+          (it "->rejected skips then and is recovered by catch"
+              (let [err (js/Error. "boom")]
+                (should= :recovered (resolved-value (.catch (fake/->rejected err) (fn [_] :recovered))))))
+
+          (it "fake cache stores and matches by request url"
+              (let [cache (fake/->cache)
+                    req   (fake/->request "https://app.test/a")
+                    resp  (fake/->response "body")]
+                (.put cache req resp)
+                (should= resp (resolved-value (.match cache req)))))
+
+          (it "fake cache addAll records urls"
+              (let [cache (fake/->cache)]
+                (.addAll cache #js ["https://app.test/x"])
+                (should-contain "https://app.test/x" (js->clj (resolved-value (.keys cache))))))
+
+          (it "fake caches opens named caches and lists/deletes them"
+              (let [caches (fake/->caches)]
+                (.open caches "one")
+                (should-contain "one" (js->clj (resolved-value (.keys caches))))
+                (should= true (resolved-value (.delete caches "one")))
+                (should-not (resolved-value (.has caches "one")))))
+
+          (it "fake-fetch resolves a response and can reject"
+              (let [req (fake/->request "https://app.test/a")]
+                (should= "ok" (.-body (resolved-value ((fake/fake-fetch (fake/->response "ok")) req))))
+                (let [caught (atom nil)]
+                  (.catch ((fake/fake-fetch :reject) req) #(reset! caught %))
+                  (should= true (instance? js/Error @caught))))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -153,3 +153,45 @@
               (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
                     req (fake/->request "https://app.test/a")]
                 (should= 503 (.-status (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))))
+
+(describe "stale-while-revalidate"
+          (it "returns cached immediately and refreshes the cache in the background"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")
+                    hit (fake/->response "stale")]
+                (seed-cache! ctx "c" req hit)
+                (should= hit (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req)))
+      ;; background revalidation overwrote the cache entry with the network response
+                (should= "fresh" (.-body (resolved-value (.then (.open (:caches ctx) "c") (fn [c] (.match c req))))))))
+
+          (it "awaits network on cache miss"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")]
+                (should= net (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req))))))
+
+(describe "network-only"
+          (it "returns the network response and caches nothing"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")]
+                (should= net (resolved-value ((sut/network-only {}) ctx req)))))
+
+          (it "returns fallback when offline"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= 503 (.-status (resolved-value ((sut/network-only {}) ctx req)))))))
+
+(describe "cache-only"
+          (it "returns cached response"
+              (let [ctx (fake/->ctx)
+                    req (fake/->request "https://app.test/a")
+                    hit (fake/->response "cached")]
+                (seed-cache! ctx "c" req hit)
+                (should= hit (resolved-value ((sut/cache-only {:cache "c"}) ctx req)))))
+
+          (it "returns fallback on miss without hitting network"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= 503 (.-status (resolved-value ((sut/cache-only {:cache "c"}) ctx req)))))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -1,6 +1,7 @@
 (ns c3kit.wire.service-worker-spec
   (:require-macros [speclj.core :refer [before context describe it should should= should-be-nil should-not should-contain]])
-  (:require [c3kit.wire.service-worker-fake :as fake]
+  (:require [c3kit.wire.js :as wjs]
+            [c3kit.wire.service-worker-fake :as fake]
             [c3kit.wire.service-worker :as sut]
             [speclj.core]))
 
@@ -224,3 +225,60 @@
               (sut/register-route! #"/img/" (sut/cache-first {:cache "images"}))
               (should-contain "shell" (sut/known-cache-names))
               (should-contain "images" (sut/known-cache-names))))
+
+(defn ->event [] (let [a (atom {})]
+                   (js-obj "waitUntil"   (fn [p] (swap! a assoc :wait p) p)
+                           "respondWith" (fn [r] (swap! a assoc :respond r) r)
+                           "__a" a)))
+(defn event-wait [e] (:wait @(unchecked-get e "__a")))
+(defn event-respond [e] (:respond @(unchecked-get e "__a")))
+
+(describe "handle-fetch"
+          (before (sut/reset-config!))
+
+          (it "routes GET to the matching strategy"
+              (sut/register-route! (fn [_] true) (fn [_ _] (fake/->resolved (fake/->response "routed"))))
+              (should= "routed" (.-body (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a"))))))
+
+          (it "uses the default handler when no route matches"
+              (sut/set-default! (fn [_ _] (fake/->resolved (fake/->response "default"))))
+              (should= "default" (.-body (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a"))))))
+
+          (it "passes non-GET straight to the network"
+              (let [net (fake/->response "net")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})]
+                (should= net (resolved-value (sut/handle-fetch ctx (fake/->request "https://app.test/a" {:method "POST"})))))))
+
+(describe "install"
+          (before (sut/reset-config!))
+
+          (it "precaches configured urls and waits on it"
+              (let [ctx (fake/->ctx) e (->event)]
+                (sut/precache! ["https://app.test/shell"] "shell")
+                (sut/install ctx e)
+                (resolved-value (event-wait e))
+                (should-contain "https://app.test/shell" (store-keys (open-cache ctx "shell"))))))
+
+(describe "activate"
+          (before (sut/reset-config!))
+
+          (it "deletes caches not in the known set and keeps known ones"
+              (let [ctx (fake/->ctx) e (->event)]
+                (sut/precache! ["/"] "keep")
+                (resolved-value (.open (:caches ctx) "keep"))
+                (resolved-value (.open (:caches ctx) "stale"))
+                (sut/activate ctx e)
+                (resolved-value (event-wait e))
+                (let [names (js->clj (resolved-value (.keys (:caches ctx))))]
+                  (should-contain "keep" names)
+                  (should-not (some #{"stale"} names))))))
+
+(describe "start!"
+          (it "registers install, activate, and fetch listeners on the scope"
+              (let [events (atom [])
+                    scope  (fake/->scope)]
+                (with-redefs [wjs/add-listener (fn [_ ev _] (swap! events conj ev))]
+                  (sut/start! (fake/->ctx {:scope scope}))
+                  (should-contain "install" @events)
+                  (should-contain "activate" @events)
+                  (should-contain "fetch" @events)))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -154,7 +154,13 @@
           (it "returns fallback when miss and network fails"
               (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
                     req (fake/->request "https://app.test/a")]
-                (should= 503 (.-status (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))))))
+                (should= 503 (.-status (resolved-value ((sut/cache-first {:cache "c"}) ctx req))))))
+
+          (it "uses custom :fallback fn on miss and network fail"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= "custom"
+                         (.-body (resolved-value ((sut/cache-first {:cache "c" :fallback (fn [_] (fake/->response "custom"))}) ctx req)))))))
 
 (describe "network-first"
           (it "fetches, caches, and returns when online"
@@ -174,7 +180,13 @@
           (it "returns 503 fallback when network fails and no cache"
               (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
                     req (fake/->request "https://app.test/a")]
-                (should= 503 (.-status (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))))
+                (should= 503 (.-status (resolved-value ((sut/network-first {:cache "c"}) ctx req))))))
+
+          (it "uses custom :fallback fn when network fails and no cache"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= "custom"
+                         (.-body (resolved-value ((sut/network-first {:cache "c" :fallback (fn [_] (fake/->response "custom"))}) ctx req)))))))
 
 (describe "stale-while-revalidate"
           (it "returns cached immediately and refreshes the cache in the background"
@@ -284,7 +296,12 @@
 
           (it "resolves to a 503 fallback when strategy returns nil"
               (sut/register-route! (fn [_] true) (fn [_ _] (fake/->resolved nil)))
-              (should= 503 (.-status (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a")))))))
+              (should= 503 (.-status (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a"))))))
+
+          (it "passes GET with no route and no default straight to the network"
+              (let [net (fake/->response "passthrough")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})]
+                (should= net (resolved-value (sut/handle-fetch ctx (fake/->request "https://app.test/a")))))))
 
 (describe "install"
           (before (sut/reset-config!))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -1,5 +1,5 @@
 (ns c3kit.wire.service-worker-spec
-  (:require-macros [speclj.core :refer [context describe it should should= should-be-nil should-not should-contain]])
+  (:require-macros [speclj.core :refer [before context describe it should should= should-be-nil should-not should-contain]])
   (:require [c3kit.wire.service-worker-fake :as fake]
             [c3kit.wire.service-worker :as sut]
             [speclj.core]))
@@ -195,3 +195,32 @@
               (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
                     req (fake/->request "https://app.test/a")]
                 (should= 503 (.-status (resolved-value ((sut/cache-only {:cache "c"}) ctx req)))))))
+
+(describe "route registry"
+          (before (sut/reset-config!))
+
+          (it "matches by predicate fn, first match wins"
+              (let [a (fn [_ _] :a) b (fn [_ _] :b)]
+                (sut/register-route! (fn [req] (re-find #"/a" (.-url req))) a)
+                (sut/register-route! (fn [_] true) b)
+                (should= a (sut/match-route (fake/->request "https://host.test/a")))
+                (should= b (sut/match-route (fake/->request "https://host.test/z")))))
+
+          (it "matches by regexp against url"
+              (sut/register-route! #"/api/" (fn [_ _] :api))
+              (should-not (nil? (sut/match-route (fake/->request "https://app.test/api/x"))))
+              (should-be-nil (sut/match-route (fake/->request "https://app.test/page"))))
+
+          (it "matches by exact pathname string"
+              (sut/register-route! "/exact" (fn [_ _] :exact))
+              (should-not (nil? (sut/match-route (fake/->request "https://app.test/exact"))))
+              (should-be-nil (sut/match-route (fake/->request "https://app.test/exact/more"))))
+
+          (it "returns nil when nothing matches"
+              (should-be-nil (sut/match-route (fake/->request "https://app.test/x"))))
+
+          (it "precache! and strategy caches populate known-cache-names"
+              (sut/precache! ["/"] "shell")
+              (sut/register-route! #"/img/" (sut/cache-first {:cache "images"}))
+              (should-contain "shell" (sut/known-cache-names))
+              (should-contain "images" (sut/known-cache-names))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -163,7 +163,7 @@
                     hit (fake/->response "stale")]
                 (seed-cache! ctx "c" req hit)
                 (should= hit (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req)))
-      ;; background revalidation overwrote the cache entry with the network response
+                ;; background revalidation overwrote the cache entry with the network response
                 (should= "fresh" (.-body (resolved-value (.then (.open (:caches ctx) "c") (fn [c] (.match c req))))))))
 
           (it "awaits network on cache miss"

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -81,3 +81,32 @@
                   (should= false (sut/cacheable? ctx a ok-resp {}))
                   (should= true  (sut/cacheable? ctx c ok-resp {:cache-credentialed true}))
                   (should= true  (sut/cacheable? ctx a ok-resp {:cache-credentialed true}))))))
+
+(defn store-keys [cache] (js->clj (resolved-value (.keys cache))))
+(defn open-cache [ctx name] (resolved-value (.open (:caches ctx) name)))
+
+(describe "fallback + cache-response!"
+          (it "->fallback returns a 503 by default"
+              (should= 503 (.-status (sut/->fallback {} (fake/->request "https://app.test/x")))))
+
+          (it "->fallback uses a provided response"
+              (let [r (fake/->response "down" {:status 200})]
+                (should= r (sut/->fallback {:fallback r} (fake/->request "https://app.test/x")))))
+
+          (it "->fallback calls a fallback fn with the request"
+              (let [req (fake/->request "https://app.test/x")]
+                (should= req (sut/->fallback {:fallback (fn [rq] rq)} req))))
+
+          (it "cache-response! stores cacheable responses and returns the original"
+              (let [ctx (fake/->ctx)
+                    req (fake/->request "https://app.test/a")
+                    rsp (fake/->response "x")]
+                (should= rsp (sut/cache-response! ctx {:cache "c"} req rsp))
+                (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+          (it "cache-response! does not store non-cacheable responses"
+              (let [ctx (fake/->ctx)
+                    req (fake/->request "https://app.test/a" {:method "POST"})
+                    rsp (fake/->response "x")]
+                (sut/cache-response! ctx {:cache "c"} req rsp)
+                (should= [] (store-keys (open-cache ctx "c"))))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -125,7 +125,13 @@
                     req (fake/->request "https://app.test/a" {:method "POST"})
                     rsp (fake/->response "x")]
                 (sut/cache-response! ctx {:cache "c"} req rsp)
-                (should= [] (store-keys (open-cache ctx "c"))))))
+                (should= [] (store-keys (open-cache ctx "c")))))
+
+          (it "cache-response! returns original response even when put rejects"
+              (let [ctx (fake/->ctx {:caches (fake/->caches {:reject-put #{"c"}})})
+                    req (fake/->request "https://app.test/a")
+                    rsp (fake/->response "x")]
+                (should= rsp (sut/cache-response! ctx {:cache "c"} req rsp)))))
 
 (defn seed-cache! [ctx name request response]
   (resolved-value (.then (.open (:caches ctx) name) (fn [c] (.put c request response)))))
@@ -185,7 +191,12 @@
               (let [net (fake/->response "fresh")
                     ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
                     req (fake/->request "https://app.test/a")]
-                (should= net (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req))))))
+                (should= net (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req)))))
+
+          (it "returns 503 fallback on cache miss when fetch also rejects"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= 503 (.-status (resolved-value ((sut/stale-while-revalidate {:cache "c"}) ctx req)))))))
 
 (describe "network-only"
           (it "returns the network response and caches nothing"
@@ -197,7 +208,14 @@
           (it "returns fallback when offline"
               (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
                     req (fake/->request "https://app.test/a")]
-                (should= 503 (.-status (resolved-value ((sut/network-only {}) ctx req)))))))
+                (should= 503 (.-status (resolved-value ((sut/network-only {}) ctx req))))))
+
+          (it "writes nothing to any cache"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")]
+                (resolved-value ((sut/network-only {}) ctx req))
+                (should= [] (store-keys (open-cache ctx "x"))))))
 
 (describe "cache-only"
           (it "returns cached response"
@@ -262,7 +280,11 @@
           (it "passes non-GET straight to the network"
               (let [net (fake/->response "net")
                     ctx (fake/->ctx {:fetch (fake/fake-fetch net)})]
-                (should= net (resolved-value (sut/handle-fetch ctx (fake/->request "https://app.test/a" {:method "POST"})))))))
+                (should= net (resolved-value (sut/handle-fetch ctx (fake/->request "https://app.test/a" {:method "POST"}))))))
+
+          (it "resolves to a 503 fallback when strategy returns nil"
+              (sut/register-route! (fn [_] true) (fn [_ _] (fake/->resolved nil)))
+              (should= 503 (.-status (resolved-value (sut/handle-fetch (fake/->ctx) (fake/->request "https://app.test/a")))))))
 
 (describe "install"
           (before (sut/reset-config!))
@@ -272,7 +294,12 @@
                 (sut/precache! ["https://app.test/shell"] "shell")
                 (sut/install ctx e)
                 (resolved-value (event-wait e))
-                (should-contain "https://app.test/shell" (store-keys (open-cache ctx "shell"))))))
+                (should-contain "https://app.test/shell" (store-keys (open-cache ctx "shell")))))
+
+          (it "does not call waitUntil when no precache is configured"
+              (let [ctx (fake/->ctx) e (->event)]
+                (sut/install ctx e)
+                (should-be-nil (event-wait e)))))
 
 (describe "activate"
           (before (sut/reset-config!))
@@ -286,7 +313,31 @@
                 (resolved-value (event-wait e))
                 (let [names (js->clj (resolved-value (.keys (:caches ctx))))]
                   (should-contain "keep" names)
-                  (should-not (some #{"stale"} names))))))
+                  (should-not (some #{"stale"} names)))))
+
+          (it "deletes two stale caches and keeps known ones"
+              (let [ctx (fake/->ctx) e (->event)]
+                (sut/precache! ["/"] "keep")
+                (resolved-value (.open (:caches ctx) "keep"))
+                (resolved-value (.open (:caches ctx) "stale1"))
+                (resolved-value (.open (:caches ctx) "stale2"))
+                (sut/activate ctx e)
+                (resolved-value (event-wait e))
+                (let [names (js->clj (resolved-value (.keys (:caches ctx))))]
+                  (should-contain "keep" names)
+                  (should-not (some #{"stale1"} names))
+                  (should-not (some #{"stale2"} names)))))
+
+          (it "claims clients even when a stale cache delete rejects"
+              (let [ctx   (fake/->ctx {:caches (fake/->caches {:reject-delete #{"stale"}})})
+                    e     (->event)
+                    scope (:scope ctx)]
+                (sut/precache! ["/"] "keep")
+                (resolved-value (.open (:caches ctx) "keep"))
+                (resolved-value (.open (:caches ctx) "stale"))
+                (sut/activate ctx e)
+                (resolved-value (event-wait e))
+                (should= true @(unchecked-get scope "__claimed_atom")))))
 
 (describe "start!"
           (it "registers install, activate, and fetch listeners on the scope"

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -110,3 +110,46 @@
                     rsp (fake/->response "x")]
                 (sut/cache-response! ctx {:cache "c"} req rsp)
                 (should= [] (store-keys (open-cache ctx "c"))))))
+
+(defn seed-cache! [ctx name request response]
+  (resolved-value (.then (.open (:caches ctx) name) (fn [c] (.put c request response)))))
+
+(describe "cache-first"
+          (it "returns cached response without fetching"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")
+                    hit (fake/->response "cached")]
+                (seed-cache! ctx "c" req hit)
+                (should= hit (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))))
+
+          (it "fetches, caches, and returns on cache miss"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")]
+                (should= net (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))
+                (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+          (it "returns fallback when miss and network fails"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= 503 (.-status (resolved-value ((sut/cache-first {:cache "c"}) ctx req)))))))
+
+(describe "network-first"
+          (it "fetches, caches, and returns when online"
+              (let [net (fake/->response "fresh")
+                    ctx (fake/->ctx {:fetch (fake/fake-fetch net)})
+                    req (fake/->request "https://app.test/a")]
+                (should= net (resolved-value ((sut/network-first {:cache "c"}) ctx req)))
+                (should-contain "https://app.test/a" (store-keys (open-cache ctx "c")))))
+
+          (it "falls back to cache when network fails"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")
+                    hit (fake/->response "cached")]
+                (seed-cache! ctx "c" req hit)
+                (should= hit (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))
+
+          (it "returns 503 fallback when network fails and no cache"
+              (let [ctx (fake/->ctx {:fetch (fake/fake-fetch :reject)})
+                    req (fake/->request "https://app.test/a")]
+                (should= 503 (.-status (resolved-value ((sut/network-first {:cache "c"}) ctx req)))))))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -1,5 +1,5 @@
 (ns c3kit.wire.service-worker-spec
-  (:require-macros [speclj.core :refer [before context describe it should should= should-be-nil should-not should-contain]])
+  (:require-macros [speclj.core :refer [before context describe it should should= should-be-nil should-not should-contain with]])
   (:require [c3kit.wire.js :as wjs]
             [c3kit.wire.service-worker-fake :as fake]
             [c3kit.wire.service-worker :as sut]
@@ -48,40 +48,55 @@
                   (should= true (instance? js/Error @caught))))))
 
 (describe "cacheable?"
-          (let [ctx (fake/->ctx {:scope (fake/->scope {:origin "https://app.test"})})
-                get-req (fake/->request "https://app.test/img.png")
-                ok-resp (fake/->response "x")]
+          (with ctx (fake/->ctx {:scope (fake/->scope {:origin "https://app.test"})}))
+          (with get-req (fake/->request "https://app.test/img.png"))
+          (with ok-resp (fake/->response "x"))
 
-            (it "true for same-origin ok GET"
-                (should= true (sut/cacheable? ctx get-req ok-resp {})))
+          (it "true for same-origin ok GET"
+              (should= true (sut/cacheable? @ctx @get-req @ok-resp {})))
 
-            (it "false for non-GET"
-                (should= false (sut/cacheable? ctx (fake/->request "https://app.test/x" {:method "POST"}) ok-resp {})))
+          (it "false for non-GET"
+              (should= false (sut/cacheable? @ctx (fake/->request "https://app.test/x" {:method "POST"}) @ok-resp {})))
 
-            (it "false for non-ok response"
-                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:ok false}) {})))
+          (it "false for non-ok response"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:ok false}) {})))
 
-            (it "false for opaque response"
-                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:type "opaque"}) {})))
+          (it "false for opaque response"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:type "opaque"}) {})))
 
-            (it "false for opaqueredirect response"
-                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:type "opaqueredirect"}) {})))
+          (it "false for opaqueredirect response"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:type "opaqueredirect"}) {})))
 
-            (it "false for no-store response"
-                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:headers {"Cache-Control" "no-store"}}) {})))
+          (it "false for no-store response"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Cache-Control" "no-store"}}) {})))
 
-            (it "false for cross-origin by default, true when allowed"
-                (let [x (fake/->request "https://cdn.other/x.png")]
-                  (should= false (sut/cacheable? ctx x ok-resp {}))
-                  (should= true  (sut/cacheable? ctx x ok-resp {:allow-cross-origin true}))))
+          (it "false for cross-origin by default, true when allowed"
+              (let [x (fake/->request "https://cdn.other/x.png")]
+                (should= false (sut/cacheable? @ctx x @ok-resp {}))
+                (should= true  (sut/cacheable? @ctx x @ok-resp {:allow-cross-origin true}))))
 
-            (it "false for credentialed by default, true when allowed"
-                (let [c (fake/->request "https://app.test/x" {:credentials "include"})
-                      a (fake/->request "https://app.test/x" {:headers {"Authorization" "Bearer t"}})]
-                  (should= false (sut/cacheable? ctx c ok-resp {}))
-                  (should= false (sut/cacheable? ctx a ok-resp {}))
-                  (should= true  (sut/cacheable? ctx c ok-resp {:cache-credentialed true}))
-                  (should= true  (sut/cacheable? ctx a ok-resp {:cache-credentialed true}))))))
+          (it "false for credentialed by default, true when allowed"
+              (let [c (fake/->request "https://app.test/x" {:credentials "include"})
+                    a (fake/->request "https://app.test/x" {:headers {"Authorization" "Bearer t"}})]
+                (should= false (sut/cacheable? @ctx c @ok-resp {}))
+                (should= false (sut/cacheable? @ctx a @ok-resp {}))
+                (should= true  (sut/cacheable? @ctx c @ok-resp {:cache-credentialed true}))
+                (should= true  (sut/cacheable? @ctx a @ok-resp {:cache-credentialed true}))))
+
+          (it "false for Cache-Control: private"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Cache-Control" "private, max-age=0"}}) {})))
+
+          (it "false for Cache-Control: no-cache"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Cache-Control" "no-cache"}}) {})))
+
+          (it "false for Vary: Cookie"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Vary" "Cookie"}}) {})))
+
+          (it "false for Vary: *"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Vary" "*"}}) {})))
+
+          (it "false when Set-Cookie present"
+              (should= false (sut/cacheable? @ctx @get-req (fake/->response "x" {:headers {"Set-Cookie" "sid=abc"}}) {}))))
 
 (defn store-keys [cache] (js->clj (resolved-value (.keys cache))))
 (defn open-cache [ctx name] (resolved-value (.open (:caches ctx) name)))

--- a/spec/cljs/c3kit/wire/service_worker_spec.cljs
+++ b/spec/cljs/c3kit/wire/service_worker_spec.cljs
@@ -1,6 +1,7 @@
 (ns c3kit.wire.service-worker-spec
   (:require-macros [speclj.core :refer [context describe it should should= should-be-nil should-not should-contain]])
   (:require [c3kit.wire.service-worker-fake :as fake]
+            [c3kit.wire.service-worker :as sut]
             [speclj.core]))
 
 (defn resolved-value [thenable]
@@ -44,3 +45,39 @@
                 (let [caught (atom nil)]
                   (.catch ((fake/fake-fetch :reject) req) #(reset! caught %))
                   (should= true (instance? js/Error @caught))))))
+
+(describe "cacheable?"
+          (let [ctx (fake/->ctx {:scope (fake/->scope {:origin "https://app.test"})})
+                get-req (fake/->request "https://app.test/img.png")
+                ok-resp (fake/->response "x")]
+
+            (it "true for same-origin ok GET"
+                (should= true (sut/cacheable? ctx get-req ok-resp {})))
+
+            (it "false for non-GET"
+                (should= false (sut/cacheable? ctx (fake/->request "https://app.test/x" {:method "POST"}) ok-resp {})))
+
+            (it "false for non-ok response"
+                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:ok false}) {})))
+
+            (it "false for opaque response"
+                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:type "opaque"}) {})))
+
+            (it "false for opaqueredirect response"
+                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:type "opaqueredirect"}) {})))
+
+            (it "false for no-store response"
+                (should= false (sut/cacheable? ctx get-req (fake/->response "x" {:headers {"Cache-Control" "no-store"}}) {})))
+
+            (it "false for cross-origin by default, true when allowed"
+                (let [x (fake/->request "https://cdn.other/x.png")]
+                  (should= false (sut/cacheable? ctx x ok-resp {}))
+                  (should= true  (sut/cacheable? ctx x ok-resp {:allow-cross-origin true}))))
+
+            (it "false for credentialed by default, true when allowed"
+                (let [c (fake/->request "https://app.test/x" {:credentials "include"})
+                      a (fake/->request "https://app.test/x" {:headers {"Authorization" "Bearer t"}})]
+                  (should= false (sut/cacheable? ctx c ok-resp {}))
+                  (should= false (sut/cacheable? ctx a ok-resp {}))
+                  (should= true  (sut/cacheable? ctx c ok-resp {:cache-credentialed true}))
+                  (should= true  (sut/cacheable? ctx a ok-resp {:cache-credentialed true}))))))

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -42,7 +42,9 @@
 (defn- cache-put [ctx name request response]
   (.then (open-cache ctx name) (fn [cache] (.put cache request response))))
 
-(defn ->fallback [opts request]
+(defn ->fallback
+  "Return a fallback Response: calls :fallback fn, returns :fallback value, or synthesizes a 503."
+  [opts request]
   (let [fb (:fallback opts)]
     (cond
       (fn? fb)   (fb request)
@@ -65,7 +67,9 @@
 
 (defn- invoke-fetch [ctx request] ((:fetch ctx) request))
 
-(defn cache-first [opts]
+(defn cache-first
+  "Strategy: serve from cache; on miss fetch, cache, and return; fallback on any error."
+  [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
     (-> (cache-match ctx (:cache opts) request)
@@ -75,7 +79,9 @@
                             (fn [response] (cache-response! ctx opts request response))))))
         (.catch (fn [_] (->fallback opts request))))))
 
-(defn network-first [opts]
+(defn network-first
+  "Strategy: fetch from network and cache; on network error serve from cache; if the cache also misses, return the fallback."
+  [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
     (-> (invoke-fetch ctx request)
@@ -84,7 +90,13 @@
                   (.then (cache-match ctx (:cache opts) request)
                          (fn [cached] (or cached (->fallback opts request)))))))))
 
-(defn stale-while-revalidate [opts]
+(defn stale-while-revalidate
+  "Strategy: serve cached immediately; refresh cache from network in background; await network on miss.
+   Note: the background revalidation is fire-and-forget — it is not wrapped in event.waitUntil (the
+   strategy has no access to the fetch event), so a browser may terminate the worker before the refresh
+   write completes. The cache still refreshes on a normal page that stays alive; the next request gets the
+   prior cached value and triggers a fresh revalidation."
+  [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
     (.then (cache-match ctx (:cache opts) request)
@@ -94,11 +106,15 @@
                                (.catch (fn [_] (->fallback opts request))))]
                (or cached network))))))
 
-(defn network-only [opts]
+(defn network-only
+  "Strategy: always fetch from network; no caching; fallback on network error."
+  [opts]
   (fn [ctx request]
     (.catch (invoke-fetch ctx request) (fn [_] (->fallback opts request)))))
 
-(defn cache-only [opts]
+(defn cache-only
+  "Strategy: serve from cache only; no network; fallback on cache miss."
+  [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
     (.then (cache-match ctx (:cache opts) request)
@@ -110,7 +126,9 @@
 (defonce ^:private default-handler (atom nil))
 (defonce ^:private precache-config (atom nil))
 
-(defn reset-config! []
+(defn reset-config!
+  "Reset all route, default-handler, precache, and known-cache state to empty."
+  []
   (reset! routes [])
   (reset! default-handler nil)
   (reset! precache-config nil)
@@ -123,41 +141,57 @@
     (string? m)  (fn [request] (= m (.-pathname (js/URL. (.-url request)))))
     :else        (throw (ex-info "invalid route matcher" {:matcher m}))))
 
-(defn register-route! [matcher strategy]
+(defn register-route!
+  "Register a strategy for requests matching matcher (fn, regexp, or exact-pathname string)."
+  [matcher strategy]
   (swap! routes conj {:match (->matcher matcher) :handler strategy})
   nil)
 
-(defn set-default! [strategy] (reset! default-handler strategy) nil)
+(defn set-default!
+  "Set the fallback strategy used when no registered route matches a GET request."
+  [strategy] (reset! default-handler strategy) nil)
 
-(defn match-route [request]
+(defn match-route
+  "Return the first registered strategy whose matcher accepts request, or nil."
+  [request]
   (some (fn [{:keys [match handler]}] (when (match request) handler)) @routes))
 
-(defn precache! [urls cache-name]
+(defn precache!
+  "Configure urls to be fetched and stored in cache-name during the install event."
+  [urls cache-name]
   (register-cache! cache-name)
   (reset! precache-config {:cache cache-name :urls (vec urls)})
   nil)
 
-(defn known-cache-names [] @known-caches)
+(defn known-cache-names
+  "Return the set of cache names registered by strategies and precache! (used during activate purge)."
+  [] @known-caches)
 
 ;; ---- lifecycle -------------------------------------------------------------
 
 (defn- network-passthrough [ctx request] (invoke-fetch ctx request))
 
-(defn handle-fetch [ctx request]
+(defn handle-fetch
+  "Dispatch a fetch event's request to the matching route strategy, default handler, or network passthrough."
+  [ctx request]
   (if (= "GET" (.-method request))
     (if-let [handler (or (match-route request) @default-handler)]
       (handler ctx request)
       (network-passthrough ctx request))
     (network-passthrough ctx request)))
 
-(defn install [ctx event]
+(defn install
+  "Handle the SW install event: skipWaiting and precache configured urls if any."
+  [ctx event]
   (log/info "[ServiceWorker] install")
   (.skipWaiting (:scope ctx))
   (when-let [{:keys [cache urls]} @precache-config]
     (.waitUntil event
                 (.then (open-cache ctx cache) (fn [c] (.addAll c (clj->js urls)))))))
 
-(defn activate [ctx event]
+(defn activate
+  "Handle the SW activate event: delete stale caches not in known-cache-names, then claim clients."
+  [ctx event]
   (log/info "[ServiceWorker] activate")
   (let [keep?  (known-cache-names)
         caches (:caches ctx)
@@ -176,12 +210,15 @@
 (defn- fetch-listener [ctx event]
   (.respondWith event (handle-fetch ctx (.-request event))))
 
-(defn ctx-from-globals []
+(defn ctx-from-globals
+  "Build a production ctx map from ServiceWorkerGlobalScope globals (js/caches, js/fetch, js/self)."
+  []
   {:caches js/caches
    :fetch  (fn [request] (js/fetch request))
    :scope  js/self})
 
 (defn start!
+  "Wire install, activate, and fetch listeners onto the SW scope. Calls ctx-from-globals when ctx omitted."
   ([] (start! (ctx-from-globals)))
   ([ctx]
    (wjs/add-listener (:scope ctx) "install"  (fn [e] (install ctx e)))

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -94,7 +94,8 @@
 (defn- invoke-fetch [ctx request] ((:fetch ctx) request))
 
 (defn cache-first
-  "Strategy: serve from cache; on miss fetch, cache, and return; fallback on any error."
+  "Strategy: serve from cache; on miss fetch, cache, and return; fallback on any error.
+   Accepts :allow-cross-origin and :cache-credentialed — these relax the security gate; pair with a tight matcher."
   [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
@@ -106,7 +107,8 @@
         (.catch (fn [err] (log/warn "[ServiceWorker] cache-first error:" err) (->fallback opts request))))))
 
 (defn network-first
-  "Strategy: fetch from network and cache; on network error serve from cache; if the cache also misses, return the fallback."
+  "Strategy: fetch from network and cache; on network error serve from cache; if the cache also misses, return the fallback.
+   Accepts :allow-cross-origin and :cache-credentialed — these relax the security gate; pair with a tight matcher."
   [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
@@ -122,7 +124,8 @@
    Note: the background revalidation is fire-and-forget — it is not wrapped in event.waitUntil (the
    strategy has no access to the fetch event), so a browser may terminate the worker before the refresh
    write completes. The cache still refreshes on a normal page that stays alive; the next request gets the
-   prior cached value and triggers a fresh revalidation."
+   prior cached value and triggers a fresh revalidation.
+   Accepts :allow-cross-origin and :cache-credentialed — these relax the security gate; pair with a tight matcher."
   [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]
@@ -134,13 +137,15 @@
                (or cached network))))))
 
 (defn network-only
-  "Strategy: always fetch from network; no caching; fallback on network error."
+  "Strategy: always fetch from network; no caching; fallback on network error.
+   Does not accept :allow-cross-origin or :cache-credentialed (nothing is cached)."
   [opts]
   (fn [ctx request]
     (.catch (invoke-fetch ctx request) (fn [err] (log/warn "[ServiceWorker] network-only error:" err) (->fallback opts request)))))
 
 (defn cache-only
-  "Strategy: serve from cache only; no network; fallback on cache miss."
+  "Strategy: serve from cache only; no network; fallback on cache miss.
+   Accepts :allow-cross-origin and :cache-credentialed — these relax the security gate; pair with a tight matcher."
   [opts]
   (register-cache! (:cache opts))
   (fn [ctx request]

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -1,0 +1,33 @@
+(ns c3kit.wire.service-worker
+  "Secure-by-default offline caching for service workers. All handlers take an
+   injected ctx {:caches :fetch :scope} (DIP) and only chain .then/.catch on the
+   thenables those injected objects return — never constructing js/Promise — so the
+   same code runs async in production and synchronously under test."
+  (:require [c3kit.apron.log :as log]
+            [c3kit.wire.js :as wjs]
+            [clojure.string :as str]))
+
+;; ---- security policy -------------------------------------------------------
+
+(defn- scope-origin [ctx] (.. (:scope ctx) -location -origin))
+(defn- request-origin [request] (.-origin (js/URL. (.-url request))))
+(defn- same-origin? [ctx request] (= (scope-origin ctx) (request-origin request)))
+
+(defn- opaque? [response] (boolean (#{"opaque" "opaqueredirect"} (.-type response))))
+
+(defn- no-store? [response]
+  (boolean (some-> (.. response -headers) (.get "Cache-Control") (str/includes? "no-store"))))
+
+(defn- credentialed? [request]
+  (or (= "include" (.-credentials request))
+      (boolean (some-> (.-headers request) (.get "Authorization")))))
+
+(defn cacheable?
+  "Should this response be written to the cache? Secure by default."
+  [ctx request response opts]
+  (and (= "GET" (.-method request))
+       (boolean (.-ok response))
+       (not (opaque? response))
+       (not (no-store? response))
+       (or (:allow-cross-origin opts) (same-origin? ctx request))
+       (or (:cache-credentialed opts) (not (credentialed? request)))))

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -84,3 +84,23 @@
                   (.then (cache-match ctx (:cache opts) request)
                          (fn [cached] (or cached (->fallback opts request)))))))))
 
+(defn stale-while-revalidate [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (.then (cache-match ctx (:cache opts) request)
+           (fn [cached]
+             (let [network (-> (invoke-fetch ctx request)
+                               (.then (fn [response] (cache-response! ctx opts request response)))
+                               (.catch (fn [_] (->fallback opts request))))]
+               (or cached network))))))
+
+(defn network-only [opts]
+  (fn [ctx request]
+    (.catch (invoke-fetch ctx request) (fn [_] (->fallback opts request)))))
+
+(defn cache-only [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (.then (cache-match ctx (:cache opts) request)
+           (fn [cached] (or cached (->fallback opts request))))))
+

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -104,3 +104,38 @@
     (.then (cache-match ctx (:cache opts) request)
            (fn [cached] (or cached (->fallback opts request))))))
 
+;; ---- route registry --------------------------------------------------------
+
+(defonce ^:private routes (atom []))
+(defonce ^:private default-handler (atom nil))
+(defonce ^:private precache-config (atom nil))
+
+(defn reset-config! []
+  (reset! routes [])
+  (reset! default-handler nil)
+  (reset! precache-config nil)
+  (reset! known-caches #{}))
+
+(defn- ->matcher [m]
+  (cond
+    (fn? m)      m
+    (regexp? m)  (fn [request] (boolean (re-find m (.-url request))))
+    (string? m)  (fn [request] (= m (.-pathname (js/URL. (.-url request)))))
+    :else        (throw (ex-info "invalid route matcher" {:matcher m}))))
+
+(defn register-route! [matcher strategy]
+  (swap! routes conj {:match (->matcher matcher) :handler strategy})
+  nil)
+
+(defn set-default! [strategy] (reset! default-handler strategy) nil)
+
+(defn match-route [request]
+  (some (fn [{:keys [match handler]}] (when (match request) handler)) @routes))
+
+(defn precache! [urls cache-name]
+  (register-cache! cache-name)
+  (reset! precache-config {:cache cache-name :urls (vec urls)})
+  nil)
+
+(defn known-cache-names [] @known-caches)
+

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -15,20 +15,43 @@
 
 (defn- opaque? [response] (boolean (#{"opaque" "opaqueredirect"} (.-type response))))
 
-(defn- no-store? [response]
-  (boolean (some-> (.. response -headers) (.get "Cache-Control") (str/includes? "no-store"))))
+(defn- cache-control-tokens [response]
+  (some-> (.. response -headers) (.get "Cache-Control") str/lower-case (str/split #"[,\s]+")))
+
+(defn- cache-control-blocks? [response]
+  (boolean (some #{"no-store" "no-cache" "private"} (cache-control-tokens response))))
+
+(defn- vary-sensitive? [response]
+  (boolean (some-> (.. response -headers) (.get "Vary") str/lower-case
+                   (str/split #"[,\s]+")
+                   (as-> tokens (some #{"*" "cookie" "authorization"} tokens)))))
+
+(defn- set-cookie? [response]
+  (boolean (some-> (.. response -headers) (.get "Set-Cookie"))))
 
 (defn- credentialed? [request]
   (or (= "include" (.-credentials request))
       (boolean (some-> (.-headers request) (.get "Authorization")))))
 
 (defn cacheable?
-  "Should this response be written to the cache? Secure by default."
+  "Should this response be written to the cache? Secure by default.
+
+   Hard blocks (not overridable by opts):
+   - Cache-Control: no-store, no-cache, or private
+   - Vary: * or Cookie or Authorization (per-user content)
+   - Set-Cookie present (response sets session state)
+
+   Threat-model note: detects credentials via Authorization header or
+   credentials: \"include\", and blocks Vary/Set-Cookie/private/no-cache
+   responses. CANNOT detect same-origin cookie auth — apps must route
+   private cookie-authenticated endpoints to network-only (or omit caching)."
   [ctx request response opts]
   (and (= "GET" (.-method request))
        (boolean (.-ok response))
        (not (opaque? response))
-       (not (no-store? response))
+       (not (cache-control-blocks? response))
+       (not (vary-sensitive? response))
+       (not (set-cookie? response))
        (or (:allow-cross-origin opts) (same-origin? ctx request))
        (or (:cache-credentialed opts) (not (credentialed? request)))))
 

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -31,3 +31,27 @@
        (not (no-store? response))
        (or (:allow-cross-origin opts) (same-origin? ctx request))
        (or (:cache-credentialed opts) (not (credentialed? request)))))
+
+;; ---- cache helpers ---------------------------------------------------------
+
+(defn- open-cache [ctx name] (.open (:caches ctx) name))
+
+(defn- cache-match [ctx name request]
+  (.then (open-cache ctx name) (fn [cache] (.match cache request))))
+
+(defn- cache-put [ctx name request response]
+  (.then (open-cache ctx name) (fn [cache] (.put cache request response))))
+
+(defn ->fallback [opts request]
+  (let [fb (:fallback opts)]
+    (cond
+      (fn? fb)   (fb request)
+      (some? fb) fb
+      :else      (js/Response. nil #js {:status 503 :statusText "Service Unavailable"}))))
+
+(defn cache-response!
+  "Clone + cache response when the shared security policy permits. Returns response."
+  [ctx opts request response]
+  (when (cacheable? ctx request response opts)
+    (cache-put ctx (:cache opts) request (.clone response)))
+  response)

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -139,3 +139,53 @@
 
 (defn known-cache-names [] @known-caches)
 
+;; ---- lifecycle -------------------------------------------------------------
+
+(defn- network-passthrough [ctx request] (invoke-fetch ctx request))
+
+(defn handle-fetch [ctx request]
+  (if (= "GET" (.-method request))
+    (if-let [handler (or (match-route request) @default-handler)]
+      (handler ctx request)
+      (network-passthrough ctx request))
+    (network-passthrough ctx request)))
+
+(defn install [ctx event]
+  (log/info "[ServiceWorker] install")
+  (.skipWaiting (:scope ctx))
+  (when-let [{:keys [cache urls]} @precache-config]
+    (.waitUntil event
+                (.then (open-cache ctx cache) (fn [c] (.addAll c (clj->js urls)))))))
+
+(defn activate [ctx event]
+  (log/info "[ServiceWorker] activate")
+  (let [keep?  (known-cache-names)
+        caches (:caches ctx)
+        names* (.keys caches)]
+    (.waitUntil event
+                (-> names*
+                    (.then (fn [names]
+                             (reduce (fn [p name]
+                                       (if (keep? name)
+                                         p
+                                         (.then p (fn [_] (.delete caches name)))))
+                                     names*
+                                     (js->clj names))))
+                    (.then (fn [_] (.. (:scope ctx) -clients (claim))))))))
+
+(defn- fetch-listener [ctx event]
+  (.respondWith event (handle-fetch ctx (.-request event))))
+
+(defn ctx-from-globals []
+  {:caches js/caches
+   :fetch  (fn [request] (js/fetch request))
+   :scope  js/self})
+
+(defn start!
+  ([] (start! (ctx-from-globals)))
+  ([ctx]
+   (wjs/add-listener (:scope ctx) "install"  (fn [e] (install ctx e)))
+   (wjs/add-listener (:scope ctx) "activate" (fn [e] (activate ctx e)))
+   (wjs/add-listener (:scope ctx) "fetch"    (fn [e] (fetch-listener ctx e)))
+   nil))
+

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -55,3 +55,32 @@
   (when (cacheable? ctx request response opts)
     (cache-put ctx (:cache opts) request (.clone response)))
   response)
+
+;; ---- caches known to the library (for activate purge) ----------------------
+
+(defonce ^:private known-caches (atom #{}))
+(defn- register-cache! [name] (when name (swap! known-caches conj name)) name)
+
+;; ---- strategies (LSP: each returns (fn [ctx request] -> thenable<Response>)) ----
+
+(defn- invoke-fetch [ctx request] ((:fetch ctx) request))
+
+(defn cache-first [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (-> (cache-match ctx (:cache opts) request)
+        (.then (fn [cached]
+                 (or cached
+                     (.then (invoke-fetch ctx request)
+                            (fn [response] (cache-response! ctx opts request response))))))
+        (.catch (fn [_] (->fallback opts request))))))
+
+(defn network-first [opts]
+  (register-cache! (:cache opts))
+  (fn [ctx request]
+    (-> (invoke-fetch ctx request)
+        (.then (fn [response] (cache-response! ctx opts request response)))
+        (.catch (fn [_]
+                  (.then (cache-match ctx (:cache opts) request)
+                         (fn [cached] (or cached (->fallback opts request)))))))))
+

--- a/src/cljs/c3kit/wire/service_worker.cljs
+++ b/src/cljs/c3kit/wire/service_worker.cljs
@@ -75,10 +75,13 @@
       :else      (js/Response. nil #js {:status 503 :statusText "Service Unavailable"}))))
 
 (defn cache-response!
-  "Clone + cache response when the shared security policy permits. Returns response."
+  "Clone + cache response when the shared security policy permits. Returns response.
+   The cache write is fire-and-forget; any put failure (e.g. QuotaExceededError) is
+   swallowed after logging so the calling strategy is never rejected."
   [ctx opts request response]
   (when (cacheable? ctx request response opts)
-    (cache-put ctx (:cache opts) request (.clone response)))
+    (.catch (cache-put ctx (:cache opts) request (.clone response))
+            (fn [err] (log/warn "[ServiceWorker] cache put failed:" err))))
   response)
 
 ;; ---- caches known to the library (for activate purge) ----------------------
@@ -100,7 +103,7 @@
                  (or cached
                      (.then (invoke-fetch ctx request)
                             (fn [response] (cache-response! ctx opts request response))))))
-        (.catch (fn [_] (->fallback opts request))))))
+        (.catch (fn [err] (log/warn "[ServiceWorker] cache-first error:" err) (->fallback opts request))))))
 
 (defn network-first
   "Strategy: fetch from network and cache; on network error serve from cache; if the cache also misses, return the fallback."
@@ -109,7 +112,8 @@
   (fn [ctx request]
     (-> (invoke-fetch ctx request)
         (.then (fn [response] (cache-response! ctx opts request response)))
-        (.catch (fn [_]
+        (.catch (fn [err]
+                  (log/warn "[ServiceWorker] network-first fetch error:" err)
                   (.then (cache-match ctx (:cache opts) request)
                          (fn [cached] (or cached (->fallback opts request)))))))))
 
@@ -126,14 +130,14 @@
            (fn [cached]
              (let [network (-> (invoke-fetch ctx request)
                                (.then (fn [response] (cache-response! ctx opts request response)))
-                               (.catch (fn [_] (->fallback opts request))))]
+                               (.catch (fn [err] (log/warn "[ServiceWorker] stale-while-revalidate error:" err) (->fallback opts request))))]
                (or cached network))))))
 
 (defn network-only
   "Strategy: always fetch from network; no caching; fallback on network error."
   [opts]
   (fn [ctx request]
-    (.catch (invoke-fetch ctx request) (fn [_] (->fallback opts request)))))
+    (.catch (invoke-fetch ctx request) (fn [err] (log/warn "[ServiceWorker] network-only error:" err) (->fallback opts request)))))
 
 (defn cache-only
   "Strategy: serve from cache only; no network; fallback on cache miss."
@@ -195,13 +199,19 @@
 (defn- network-passthrough [ctx request] (invoke-fetch ctx request))
 
 (defn handle-fetch
-  "Dispatch a fetch event's request to the matching route strategy, default handler, or network passthrough."
+  "Dispatch a fetch event's request to the matching route strategy, default handler, or network passthrough.
+   Guards the resolved value: if a strategy resolves to nil/undefined (which would cause
+   respondWith(undefined) to crash the page), substitutes a 503 fallback response."
   [ctx request]
-  (if (= "GET" (.-method request))
-    (if-let [handler (or (match-route request) @default-handler)]
-      (handler ctx request)
-      (network-passthrough ctx request))
-    (network-passthrough ctx request)))
+  (let [thenable (if (= "GET" (.-method request))
+                   (if-let [handler (or (match-route request) @default-handler)]
+                     (handler ctx request)
+                     (network-passthrough ctx request))
+                   (network-passthrough ctx request))]
+    (.then thenable (fn [resp]
+                      (if (some? resp)
+                        resp
+                        (->fallback {} request))))))
 
 (defn install
   "Handle the SW install event: skipWaiting and precache configured urls if any."
@@ -213,7 +223,9 @@
                 (.then (open-cache ctx cache) (fn [c] (.addAll c (clj->js urls)))))))
 
 (defn activate
-  "Handle the SW activate event: delete stale caches not in known-cache-names, then claim clients."
+  "Handle the SW activate event: delete stale caches not in known-cache-names, then claim clients.
+   Each cache delete is best-effort: a rejected delete (e.g. cache locked/busy) is logged and
+   swallowed so that clients.claim is always reached."
   [ctx event]
   (log/info "[ServiceWorker] activate")
   (let [keep?  (known-cache-names)
@@ -225,7 +237,10 @@
                              (reduce (fn [p name]
                                        (if (keep? name)
                                          p
-                                         (.then p (fn [_] (.delete caches name)))))
+                                         (.then p (fn [_]
+                                                    (.catch (.delete caches name)
+                                                            (fn [err]
+                                                              (log/warn "[ServiceWorker] cache delete failed for" name ":" err)))))))
                                      names*
                                      (js->clj names))))
                     (.then (fn [_] (.. (:scope ctx) -clients (claim))))))))

--- a/src/cljs/c3kit/wire/service_worker_fake.cljs
+++ b/src/cljs/c3kit/wire/service_worker_fake.cljs
@@ -1,0 +1,76 @@
+(ns c3kit.wire.service-worker-fake
+  "In-memory test doubles for service-worker specs. Shipped in src so apps that
+   build their own SW config can reuse them. Includes a synchronous promise double
+   so SW handlers (which only chain .then/.catch on injected thenables) resolve
+   synchronously under test.")
+
+(declare ->resolved)
+
+(defn ->rejected [err]
+  (js-obj
+   "then"  (fn [_] (->rejected err))
+   "catch" (fn [f] (->resolved (f err)))))
+
+(defn ->resolved [v]
+  (if (and v (fn? (unchecked-get v "then")))
+    v
+    (js-obj
+     "then"  (fn [f] (try (->resolved (f v)) (catch :default e (->rejected e))))
+     "catch" (fn [_] (->resolved v)))))
+
+(defn ->headers [m]
+  (let [m (or m {})]
+    (js-obj "get" (fn [k] (get m k)))))
+
+(defn ->request [url & [{:keys [method headers credentials] :or {method "GET"}}]]
+  (js-obj "url" url "method" method "credentials" credentials "headers" (->headers headers)))
+
+(defn ->response [body & [opts]]
+  (let [{:keys [ok type status headers] :or {ok true type "basic" status 200}} opts]
+    (js-obj "ok" ok "type" type "status" status "body" body
+            "headers" (->headers headers)
+            "clone" (fn [] (->response body opts)))))
+
+(defn- req-url [r] (if (string? r) r (unchecked-get r "url")))
+
+(defn ->cache []
+  (let [store (atom {})]
+    (js-obj
+     "match"  (fn [request] (->resolved (get @store (req-url request))))
+     "put"    (fn [request response] (swap! store assoc (req-url request) response) (->resolved nil))
+     "addAll" (fn [urls] (doseq [u (js->clj urls)] (swap! store assoc u :precached)) (->resolved nil))
+     "keys"   (fn [] (->resolved (clj->js (keys @store))))
+     "delete" (fn [request]
+                (let [k (req-url request) had (contains? @store k)]
+                  (swap! store dissoc k) (->resolved had)))
+     "__store" store)))
+
+(defn ->caches []
+  (let [caches (atom {})]
+    (js-obj
+     "open"   (fn [name]
+                (when-not (contains? @caches name) (swap! caches assoc name (->cache)))
+                (->resolved (get @caches name)))
+     "keys"   (fn [] (->resolved (clj->js (keys @caches))))
+     "has"    (fn [name] (->resolved (contains? @caches name)))
+     "delete" (fn [name]
+                (let [had (contains? @caches name)]
+                  (swap! caches dissoc name) (->resolved had)))
+     "__caches" caches)))
+
+(defn ->scope [& [{:keys [origin] :or {origin "https://app.test"}}]]
+  (js-obj
+   "location"         (js-obj "origin" origin)
+   "skipWaiting"      (fn [] (->resolved nil))
+   "clients"          (js-obj "claim" (fn [] (->resolved nil)))
+   "addEventListener" (fn [_ _])))
+
+(defn fake-fetch [resp-or-fn]
+  (fn [request]
+    (let [r (if (fn? resp-or-fn) (resp-or-fn request) resp-or-fn)]
+      (if (= :reject r) (->rejected (js/Error. "network fail")) (->resolved r)))))
+
+(defn ->ctx [& [{:keys [caches fetch scope]}]]
+  {:caches (or caches (->caches))
+   :fetch  (or fetch (fake-fetch (->response "ok")))
+   :scope  (or scope (->scope))})

--- a/src/cljs/c3kit/wire/service_worker_fake.cljs
+++ b/src/cljs/c3kit/wire/service_worker_fake.cljs
@@ -33,11 +33,17 @@
 
 (defn- req-url [r] (if (string? r) r (unchecked-get r "url")))
 
-(defn ->cache []
+(defn ->cache
+  "Creates a fake Cache. Options:
+   :reject-put? - when true, .put returns a rejected thenable (simulates QuotaExceededError)"
+  [& [{:keys [reject-put?]}]]
   (let [store (atom {})]
     (js-obj
      "match"  (fn [request] (->resolved (get @store (req-url request))))
-     "put"    (fn [request response] (swap! store assoc (req-url request) response) (->resolved nil))
+     "put"    (fn [request response]
+                (if reject-put?
+                  (->rejected (js/Error. "QuotaExceededError"))
+                  (do (swap! store assoc (req-url request) response) (->resolved nil))))
      "addAll" (fn [urls] (doseq [u (js->clj urls)] (swap! store assoc u :precached)) (->resolved nil))
      "keys"   (fn [] (->resolved (clj->js (vec (keys @store)))))
      "delete" (fn [request]
@@ -45,25 +51,38 @@
                   (swap! store dissoc k) (->resolved had)))
      "__store" store)))
 
-(defn ->caches []
+(defn ->caches
+  "Creates a fake CacheStorage. Options:
+   :reject-delete - set of cache names whose .delete should return a rejected thenable
+   :reject-put    - set of cache names whose cache's .put should return a rejected thenable"
+  [& [{:keys [reject-delete reject-put] :or {reject-delete #{} reject-put #{}}}]]
   (let [caches (atom {})]
     (js-obj
      "open"   (fn [name]
-                (when-not (contains? @caches name) (swap! caches assoc name (->cache)))
+                (when-not (contains? @caches name)
+                  (swap! caches assoc name (->cache {:reject-put? (contains? reject-put name)})))
                 (->resolved (get @caches name)))
      "keys"   (fn [] (->resolved (clj->js (vec (keys @caches)))))
      "has"    (fn [name] (->resolved (contains? @caches name)))
      "delete" (fn [name]
-                (let [had (contains? @caches name)]
-                  (swap! caches dissoc name) (->resolved had)))
+                (if (contains? reject-delete name)
+                  (->rejected (js/Error. (str "delete rejected for " name)))
+                  (let [had (contains? @caches name)]
+                    (swap! caches dissoc name) (->resolved had))))
      "__caches" caches)))
 
-(defn ->scope [& [{:keys [origin] :or {origin "https://app.test"}}]]
-  (js-obj
-   "location"         (js-obj "origin" origin)
-   "skipWaiting"      (fn [] (->resolved nil))
-   "clients"          (js-obj "claim" (fn [] (->resolved nil)))
-   "addEventListener" (fn [_ _])))
+(defn ->scope
+  "Creates a fake ServiceWorkerGlobalScope. Options:
+   :origin - the origin string (default \"https://app.test\")
+   Access __claimed_atom (an atom) to test whether clients.claim was called."
+  [& [{:keys [origin] :or {origin "https://app.test"}}]]
+  (let [claimed (atom false)]
+    (js-obj
+     "location"         (js-obj "origin" origin)
+     "skipWaiting"      (fn [] (->resolved nil))
+     "clients"          (js-obj "claim" (fn [] (reset! claimed true) (->resolved nil)))
+     "addEventListener" (fn [_ _])
+     "__claimed_atom"   claimed)))
 
 (defn fake-fetch [resp-or-fn]
   (fn [request]

--- a/src/cljs/c3kit/wire/service_worker_fake.cljs
+++ b/src/cljs/c3kit/wire/service_worker_fake.cljs
@@ -39,7 +39,7 @@
      "match"  (fn [request] (->resolved (get @store (req-url request))))
      "put"    (fn [request response] (swap! store assoc (req-url request) response) (->resolved nil))
      "addAll" (fn [urls] (doseq [u (js->clj urls)] (swap! store assoc u :precached)) (->resolved nil))
-     "keys"   (fn [] (->resolved (clj->js (keys @store))))
+     "keys"   (fn [] (->resolved (clj->js (vec (keys @store)))))
      "delete" (fn [request]
                 (let [k (req-url request) had (contains? @store k)]
                   (swap! store dissoc k) (->resolved had)))
@@ -51,7 +51,7 @@
      "open"   (fn [name]
                 (when-not (contains? @caches name) (swap! caches assoc name (->cache)))
                 (->resolved (get @caches name)))
-     "keys"   (fn [] (->resolved (clj->js (keys @caches))))
+     "keys"   (fn [] (->resolved (clj->js (vec (keys @caches)))))
      "has"    (fn [name] (->resolved (contains? @caches name)))
      "delete" (fn [name]
                 (let [had (contains? @caches name)]

--- a/src/cljs/c3kit/wire/service_worker_register.cljs
+++ b/src/cljs/c3kit/wire/service_worker_register.cljs
@@ -15,8 +15,10 @@
                                                 "activated" (when on-active (on-active registration))
                                                 nil)))))))
 
-(defn register-with [{:keys [container secure? url on-update on-active]
-                      :or   {url "/service-worker.js"}}]
+(defn register-with
+  "Register the SW using explicit deps: :container, :secure?, :url, :on-update, :on-active. Testable without globals."
+  [{:keys [container secure? url on-update on-active]
+    :or   {url "/service-worker.js"}}]
   (cond
     (not secure?)
     (do (log/warn "service worker: insecure context, skipping registration")
@@ -42,7 +44,9 @@
   [opts]
   (register-with (merge {:container (sw-container) :secure? (secure-context?)} opts)))
 
-(defn unregister! []
+(defn unregister!
+  "Unregister the current service worker registration, if any."
+  []
   (if-let [c (sw-container)]
     (-> (.getRegistration c) (.then (fn [reg] (when reg (.unregister reg)))))
     (js/Promise.resolve nil)))

--- a/src/cljs/c3kit/wire/service_worker_register.cljs
+++ b/src/cljs/c3kit/wire/service_worker_register.cljs
@@ -44,9 +44,14 @@
   [opts]
   (register-with (merge {:container (sw-container) :secure? (secure-context?)} opts)))
 
+(defn unregister-with
+  "Unregister using explicit container dep. Testable without globals."
+  [container]
+  (if container
+    (-> (.getRegistration container) (.then (fn [reg] (when reg (.unregister reg)))))
+    (js/Promise.resolve nil)))
+
 (defn unregister!
   "Unregister the current service worker registration, if any."
   []
-  (if-let [c (sw-container)]
-    (-> (.getRegistration c) (.then (fn [reg] (when reg (.unregister reg)))))
-    (js/Promise.resolve nil)))
+  (unregister-with (sw-container)))

--- a/src/cljs/c3kit/wire/service_worker_register.cljs
+++ b/src/cljs/c3kit/wire/service_worker_register.cljs
@@ -1,0 +1,48 @@
+(ns c3kit.wire.service-worker-register
+  "Page-side service-worker registration. register-with takes its secure-context
+   flag and serviceWorker container as explicit args (DIP) so it is testable
+   without global redefs; register! fills them from globals."
+  (:require [c3kit.apron.log :as log]))
+
+(defn- wire-update-callbacks [registration on-update on-active]
+  (.addEventListener registration "updatefound"
+                     (fn []
+                       (when-let [installing (.-installing registration)]
+                         (.addEventListener installing "statechange"
+                                            (fn []
+                                              (case (.-state installing)
+                                                "installed" (when on-update (on-update registration))
+                                                "activated" (when on-active (on-active registration))
+                                                nil)))))))
+
+(defn register-with [{:keys [container secure? url on-update on-active]
+                      :or   {url "/service-worker.js"}}]
+  (cond
+    (not secure?)
+    (do (log/warn "service worker: insecure context, skipping registration")
+        (js/Promise.resolve nil))
+
+    (nil? container)
+    (do (log/warn "service worker: unsupported, skipping registration")
+        (js/Promise.resolve nil))
+
+    :else
+    (-> (.register container url)
+        (.then (fn [registration]
+                 (wire-update-callbacks registration on-update on-active)
+                 (log/info "service worker registered:" url)
+                 registration))
+        (.catch (fn [err] (log/warn "service worker registration failed:" err) nil)))))
+
+(defn- sw-container [] (when (exists? js/navigator) (.-serviceWorker js/navigator)))
+(defn- secure-context? [] (boolean (and (exists? js/self) (.-isSecureContext js/self))))
+
+(defn register!
+  "Register the service worker. opts: {:url :on-update :on-active}."
+  [opts]
+  (register-with (merge {:container (sw-container) :secure? (secure-context?)} opts)))
+
+(defn unregister! []
+  (if-let [c (sw-container)]
+    (-> (.getRegistration c) (.then (fn [reg] (when reg (.unregister reg)))))
+    (js/Promise.resolve nil)))


### PR DESCRIPTION
## Service Worker library (offline-read caching) for `c3kit.wire`

Secure-by-default, SOLID, test-first ClojureScript service-worker library. Built TDD over 9 tasks (subagent-driven, per-task review + final whole-branch review + a 5-craftsmen audit).

### What it adds
Three namespaces split by JS execution scope:
- **`c3kit.wire.service-worker`** (SW-global): `cacheable?` security predicate, cache helpers, `->fallback`, gated `cache-response!`, **5 strategies** (`cache-first`, `network-first`, `stale-while-revalidate`, `network-only`, `cache-only`), a route registry (`register-route!`/`set-default!`/`match-route`/`precache!`/`known-cache-names`/`reset-config!`), and lifecycle (`handle-fetch`/`install`/`activate`/`start!`).
- **`c3kit.wire.service-worker-register`** (page): `register!`/`register-with`/`unregister!`.
- **`c3kit.wire.service-worker-fake`** (shipped in `src` for app reuse): in-memory caches/request/response/scope doubles + a **synchronous-promise double** so specs resolve synchronously with no async harness.

### Design
- **DIP:** every handler takes an injected `ctx {:caches :fetch :scope}`; globals are read only in `ctx-from-globals`. **LSP:** every strategy is `(fn [ctx request] -> thenable<Response>)`. Production constructs no `js/Promise` (only `->fallback`'s 503) — so the same code runs async in production and synchronously under test.
- **Secure by default:** all dynamic cache writes pass a single shared `cacheable?` gate — same-origin, `response.ok`, GET-only, not opaque, not `no-store`/`no-cache`/`private`, no `Vary: cookie/authorization/*`, no `Set-Cookie`, not credentialed — unless explicitly opted out via `:allow-cross-origin` / `:cache-credentialed`. Threat model is documented honestly (it does **not** auto-detect same-origin cookie auth; route private endpoints to `network-only`).

### Robustness
`activate` purges stale caches best-effort (a locked-cache `.delete` can't abort `clients.claim`); `cache-response!` swallows quota-rejection on its fire-and-forget put; strategies log swallowed errors; `handle-fetch` never resolves to `undefined` (no `respondWith(undefined)`).

### Tests
323 examples, 0 failures. (A latent speclj-cljs `it`-inside-`let` coverage hole was found and fixed — it had silently reduced the `cacheable?` block to one running test.)

### Real-world validation
Ported wilson-warehouse's hand-rolled SW to this library on a branch: clean ~1:1 mapping (precache + network-first + start!), SW build compiles under advanced optimizations, background-sync concern preserved. Two product decisions surfaced (404 returned to client vs cache-served; stricter gate blocks personalized responses).

### Docs
README usage section (SW-global setup + page registration + SWR caveat + opt-in footguns + precache atomicity), docstrings on every public fn.
