### PR TITLE
feat: add security scanning via central reusable workflow

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:hooks {:analyze-call {c3kit.wire.redis/borrow-from   hooks.redis/borrow-from
+                        c3kit.wire.redis/wait-for-all hooks.redis/wait-for-all}}}

--- a/.clj-kondo/hooks/redis.clj
+++ b/.clj-kondo/hooks/redis.clj
@@ -1,0 +1,29 @@
+(ns hooks.redis
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn borrow-from
+  "c3kit.wire.redis/borrow-from is `(borrow-from [sym pool-expr] & body)` — a
+   single-binding-pair macro shaped exactly like `let`. clj-kondo can't see
+   that `bindings` introduces a local without understanding the macro, so
+   rewrite the call to a `let` with the same binding vector — that resolves
+   the bound symbol (and any type hint on it) in `body` with no behaviour
+   change."
+  [{:keys [node]}]
+  (let [[_ bindings & body] (:children node)
+        new-node (api/list-node
+                  (list* (api/token-node 'let)
+                         bindings
+                         body))]
+    {:node (with-meta new-node (meta node))}))
+
+(defn wait-for-all
+  "c3kit.wire.redis/wait-for-all is `(wait-for-all [binding-form coll] form)` —
+   a single-iteration binding macro shaped exactly like `for`. clj-kondo can't
+   resolve the (possibly destructured) binding without understanding the
+   macro, so rewrite the call to a `for` with the same binding vector — that
+   resolves the bound symbols in `form` with no behaviour change."
+  [{:keys [node]}]
+  (let [[_ bindings form] (:children node)
+        new-node (api/list-node
+                  (list (api/token-node 'for) bindings form))]
+    {:node (with-meta new-node (meta node))}))

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,8 @@
+name: Security
+on:
+  pull_request: {}
+  workflow_call: {}
+jobs:
+  security:
+    uses: cleancoders/github-actions/.github/workflows/security.yml@v1
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.iml
+.clj-kondo/.cache
+.clj-kondo/imports
 .cpcache
 .idea
 .DS_Store

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+# gitleaks baseline (2026-07-09): pre-existing findings accepted as-is.
+# New secrets introduced after this baseline still fail CI.
+e3f0f259ca89d4e4fd1a0960816ff0e13d108a6f:spec/cljc/c3kit/wire/jwtc_spec.cljc:jwt:15
+e3f0f259ca89d4e4fd1a0960816ff0e13d108a6f:spec/cljc/c3kit/wire/jwtc_spec.cljc:jwt:28

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,5 @@
-{
- :paths   ["src/clj" "src/cljc" "src/cljs"]
- :deps    {
-           buddy/buddy-sign                 {:mvn/version "3.6.1-359"} ; Used by JWT
+{:paths   ["src/clj" "src/cljc" "src/cljs"]
+ :deps    {buddy/buddy-sign                 {:mvn/version "3.6.1-359"} ; Used by JWT
            cljs-http/cljs-http              {:mvn/version "0.1.49"}
            com.cleancoders.c3kit/apron      {:mvn/version "2.5.0"}
            compojure/compojure              {:mvn/version "1.7.2" :exclusions [ring/ring-core ring/ring-codec]}
@@ -12,10 +10,8 @@
            org.clojure/core.async           {:mvn/version "1.8.741"}
            org.redisson/redisson            {:mvn/version "3.52.0"} ; Used for Redis Locks
            ring/ring                        {:mvn/version "1.15.3"}
-           ring/ring-anti-forgery           {:mvn/version "1.4.0"}
-           }
- :aliases {
-           ;; React layer — adds the Reagent wrappers, their deps, the React-flavored specs,
+           ring/ring-anti-forgery           {:mvn/version "1.4.0"}}
+ :aliases {           ;; React layer — adds the Reagent wrappers, their deps, the React-flavored specs,
            ;; and the React scaffold cljs config. Chain this in to build/test/develop the wire jar.
            ;; dev-react/ comes before dev-core/ in classpath order (it appears earlier in the
            ;; alias chain), so its config/cljs.edn wins when both are on the classpath.
@@ -29,8 +25,7 @@
                                      com.google.api-client/google-api-client {:mvn/version "2.8.1"}
                                      io.github.clojure/tools.build           {:mvn/version "0.10.12"}
                                      clj-commons/pomegranate                 {:mvn/version "1.2.25"}}
-                     :override-deps {
-                                     ;com.cleancoders.c3kit/apron    {:local/root "../apron"}
+                     :override-deps {                                     ;com.cleancoders.c3kit/apron    {:local/root "../apron"}
                                      ;com.cleancoders.c3kit/scaffold {:local/root "../scaffold"}
                                      }
                      :extra-paths   ["dev" "spec/clj" "spec/cljc" "spec/cljs"]}
@@ -47,5 +42,6 @@
                                    clj-commons/pomegranate       {:mvn/version "1.2.25"}}
                      :ns-default  build
                      :extra-paths ["dev"]}
-           }
- }
+           :clj-watson {:replace-deps {io.github.clj-holmes/clj-watson {:git/tag "v6.1.0"
+                                                                        :git/sha "be98e4db74fb8927db4825cc73bbe2606e44e5e3"}}
+                        :main-opts    ["-m" "clj-watson.cli"]}}}

--- a/src/clj/c3kit/wire/spec_helper.clj
+++ b/src/clj/c3kit/wire/spec_helper.clj
@@ -6,7 +6,8 @@
             [c3kit.wire.flashc :as flashc]
             [c3kit.wire.lock :as lock]
             [c3kit.wire.websocket :as ws]
-            [speclj.core :refer :all]
+            [speclj.core :refer [after before it should should-contain should-have-invoked
+                                 should-not-be-nil should= stub]]
             [speclj.stub :as stub]))
 
 (log/warn!)
@@ -63,19 +64,19 @@
 
 (defmacro test-route [path method route-handler handler & body]
   `(it ~path
-     (check-route ~path ~method ~route-handler ~handler)
-     ~@body))
+       (check-route ~path ~method ~route-handler ~handler)
+       ~@body))
 
 (defmacro test-webs [id sym]
   `(it (str "remote " ~id " -> " '~sym)
-     (let [action# (ws/resolve-handler ~id)]
-       (should-not-be-nil action#)
-       (should= '~sym (.toSymbol action#)))))
+       (let [action# (ws/resolve-handler ~id)]
+         (should-not-be-nil action#)
+         (should= '~sym (.toSymbol action#)))))
 
 (defn with-memory-lock []
   (list
-    (before (lock/configure! {:impl :memory}))
-    (after (lock/shutdown!))))
+   (before (lock/configure! {:impl :memory}))
+   (after (lock/shutdown!))))
 
 (defmacro should-have-locked [key]
   `(should-contain ~key @(.-locks @lock/impl)))


### PR DESCRIPTION
Consume cleancoders/github-actions security.yml@v1 as a local wrapper on PR
(library repo, no build.yml deploy gate to wire). Add :clj-watson alias for
advisory CVE scanning. No bin/ dir, so the shellcheck-dir input is omitted
entirely.

gitleaks: 2 pre-existing "jwt" rule hits in spec/cljc/c3kit/wire/jwtc_spec.cljc
(JWT test fixtures), baselined in .gitleaksignore.

clj-holmes: no bare read-string in src/spec, nothing to fix.

clj-kondo: fixed 6 pre-existing error-level findings so the hard-fail gate
passes:
- teach clj-kondo the borrow-from (let-shaped) and wait-for-all (for-shaped)
  private macros in c3kit.wire.redis via a hook, clearing 4 false-positive
  unresolved-symbol errors
- spec-helper.clj: replace speclj.core :refer :all with an explicit :refer
  list; clj-kondo cannot resolve bare before/after through :refer :all even
  when speclj is on the analyzed classpath (verified error persists with
  :test alias included), same set of vars, no behavior change
